### PR TITLE
Support contact telephone number in EngineBlock metadata

### DIFF
--- a/manage-server/src/main/java/manage/format/EngineBlockFormatter.java
+++ b/manage-server/src/main/java/manage/format/EngineBlockFormatter.java
@@ -170,15 +170,17 @@ public class EngineBlockFormatter {
         IntStream.range(0, 4).forEach(i -> {
             String contactType = metaDataFields.get("contacts:" + i + ":contactType");
             String emailAddress = metaDataFields.get("contacts:" + i + ":emailAddress");
+            String telephoneNumber = metaDataFields.get("contacts:" + i + ":telephoneNumber");
             String givenName = metaDataFields.get("contacts:" + i + ":givenName");
             String surName = metaDataFields.get("contacts:" + i + ":surName");
 
-            if (hasText(contactType) || hasText(emailAddress) || hasText(givenName) || hasText(surName)) {
+            if (hasText(contactType) || hasText(emailAddress) || hasText(telephoneNumber) || hasText(givenName) || hasText(surName)) {
                 ArrayList<Object> contactsContainer = (ArrayList<Object>) metadata.computeIfAbsent(
                     "contacts", key -> new ArrayList<>());
                 Map<String, String> contact = new HashMap<>();
                 putIfHasText("contactType", contactType, contact);
                 putIfHasText("emailAddress", emailAddress, contact);
+                putIfHasText("telephoneNumber", telephoneNumber, contact);
                 putIfHasText("givenName", givenName, contact);
                 putIfHasText("surName", surName, contact);
                 contactsContainer.add(contact);


### PR DESCRIPTION
EngineBlock recently added support for telephone numbers of contacts
in the metadata, see:

   https://github.com/OpenConext/OpenConext-engineblock-metadata/commit/7dce82b

In order for this to work, manage should include the number in the
metadata as well - janus already does that.