### PR TITLE
Define mdui extension in SP metadata XML

### DIFF
--- a/manage-server/src/main/resources/metadata_export/saml20_sp.xml
+++ b/manage-server/src/main/resources/metadata_export/saml20_sp.xml
@@ -1,27 +1,29 @@
 <?xml version="1.0"?>
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                     xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+                     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
                      entityID="{{entityid}}" validUntil="{{validUntil}}" cacheDuration="PT86400S">
     <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         {{#UIInfoExtension}}
         <md:Extensions>
-            <md:UIInfo>
+            <mdui:UIInfo>
                 {{#metaDataFields.name:en}}
-                <md:DisplayName xml:lang="en">{{metaDataFields.name:en}}</md:DisplayName>
+                <mdui:DisplayName xml:lang="en">{{metaDataFields.name:en}}</mdui:DisplayName>
                 {{/metaDataFields.name:en}}
                 {{#metaDataFields.name:nl}}
-                <md:DisplayName xml:lang="nl">{{metaDataFields.name:nl}}</md:DisplayName>
+                <mdui:DisplayName xml:lang="nl">{{metaDataFields.name:nl}}</mdui:DisplayName>
                 {{/metaDataFields.name:nl}}
                 {{#metaDataFields.description:en}}
-                <md:Description xml:lang="en">{{metaDataFields.description:en}}</md:Description>
+                <mdui:Description xml:lang="en">{{metaDataFields.description:en}}</mdui:Description>
                 {{/metaDataFields.description:en}}
                 {{#metaDataFields.description:nl}}
-                <md:Description xml:lang="nl">{{metaDataFields.description:nl}}</md:Description>
+                <mdui:Description xml:lang="nl">{{metaDataFields.description:nl}}</mdui:Description>
                 {{/metaDataFields.description:nl}}
                 {{#Logo}}
-                <md:Logo width="{{metaDataFields.logo:0:width}}" height="{{metaDataFields.logo:0:height}}"
-                         xml:lang="en">{{metaDataFields.logo:0:url}}</md:Logo>
+                <mdui:Logo width="{{metaDataFields.logo:0:width}}" height="{{metaDataFields.logo:0:height}}"
+                         xml:lang="en">{{metaDataFields.logo:0:url}}</mdui:Logo>
                 {{/Logo}}
-            </md:UIInfo>
+            </mdui:UIInfo>
         </md:Extensions>
         {{/UIInfoExtension}}
         {{#metaDataFields.certData}}

--- a/manage-server/src/test/resources/xml/expected_metadata_export_saml20_sp.xml
+++ b/manage-server/src/test/resources/xml/expected_metadata_export_saml20_sp.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0"?>
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                     xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+                     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
                      entityID="https://teams.surfconext.nl/shibboleth" >
     <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         <md:Extensions>
-            <md:UIInfo>
-                <md:DisplayName xml:lang="en">SURFconext Teams | SURFnet</md:DisplayName>
-                <md:DisplayName xml:lang="nl">SURFconext Teams | SURFnet</md:DisplayName>
-                <md:Description xml:lang="en">Teams for SURFconext.</md:Description>
-                <md:Description xml:lang="nl">Teams voor SURFconext.</md:Description>
-                <md:Logo width="500" height="300"
-                         xml:lang="en">https://static.surfconext.nl/media/sp/SURFnetdienst.png</md:Logo>
-            </md:UIInfo>
+            <mdui:UIInfo>
+                <mdui:DisplayName xml:lang="en">SURFconext Teams | SURFnet</mdui:DisplayName>
+                <mdui:DisplayName xml:lang="nl">SURFconext Teams | SURFnet</mdui:DisplayName>
+                <mdui:Description xml:lang="en">Teams for SURFconext.</mdui:Description>
+                <mdui:Description xml:lang="nl">Teams voor SURFconext.</mdui:Description>
+                <mdui:Logo width="500" height="300"
+                         xml:lang="en">https://static.surfconext.nl/media/sp/SURFnetdienst.png</mdui:Logo>
+            </mdui:UIInfo>
         </md:Extensions>
         <md:KeyDescriptor use="signing">
             <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">

--- a/manage-server/src/test/resources/xml/metadata_import_saml20_sp.xml
+++ b/manage-server/src/test/resources/xml/metadata_import_saml20_sp.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0"?>
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                     xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+                     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
                      entityID="https://teams.surfconext.nl/shibboleth" validUntil="2018-07-14T11:15:56.857+02:00"
                      cacheDuration="PT86400S">
     <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         <md:Extensions>
-            <md:UIInfo>
-                <md:DisplayName xml:lang="en">name-en</md:DisplayName>
-                <md:DisplayName xml:lang="nl">name-nl</md:DisplayName>
-                <md:Description xml:lang="en">description-en</md:Description>
-                <md:Description xml:lang="nl">description-nl</md:Description>
-                <md:Logo width="400" height="500" xml:lang="en">https://url</md:Logo>
-            </md:UIInfo>
+            <mdui:UIInfo>
+                <mdui:DisplayName xml:lang="en">name-en</mdui:DisplayName>
+                <mdui:DisplayName xml:lang="nl">name-nl</mdui:DisplayName>
+                <mdui:Description xml:lang="en">description-en</mdui:Description>
+                <mdui:Description xml:lang="nl">description-nl</mdui:Description>
+                <mdui:Logo width="400" height="500" xml:lang="en">https://url</mdui:Logo>
+            </mdui:UIInfo>
         </md:Extensions>
         <md:KeyDescriptor use="signing">
             <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">


### PR DESCRIPTION
The UIInfo element is part of SAML:2.0:metadata:ui schema and not the
SAML:2.0:metadata schema. The SP metadata XML now reflects this,
allowing validation using the XSD.