### PR TITLE
Log error message when contract not met

### DIFF
--- a/manage-server/src/main/java/manage/shibboleth/ShibbolethPreAuthenticatedProcessingFilter.java
+++ b/manage-server/src/main/java/manage/shibboleth/ShibbolethPreAuthenticatedProcessingFilter.java
@@ -12,6 +12,9 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static org.springframework.security.core.authority.AuthorityUtils.createAuthorityList;
 
 public class ShibbolethPreAuthenticatedProcessingFilter extends AbstractPreAuthenticatedProcessingFilter {
@@ -22,6 +25,7 @@ public class ShibbolethPreAuthenticatedProcessingFilter extends AbstractPreAuthe
     private final List<Features> featureToggles;
     private final Product product;
     private final Push push;
+    private static final Logger log = LoggerFactory.getLogger(ShibbolethPreAuthenticatedProcessingFilter.class);
 
     public ShibbolethPreAuthenticatedProcessingFilter(AuthenticationManager authenticationManager, List<Features>
         featureToggles, Product product, Push push) {
@@ -40,6 +44,7 @@ public class ShibbolethPreAuthenticatedProcessingFilter extends AbstractPreAuthe
 
         if (StringUtils.isEmpty(uid) || StringUtils.isEmpty(displayName)) {
             //this is the contract. See AbstractPreAuthenticatedProcessingFilter#doAuthenticate
+            log.error("Missing required attributes.");
             return null;
         }
         //TODO determine guest membership based on ???


### PR DESCRIPTION
I was missing a displayName and this has proven to be quite difficult to debug.. On the Shibboleth-side everything seems fine, session is succesfully started, etc... On the Manage-side a HTTP basic auth pop-up and no meaningful logging.

I'm sure there's a better way of fixing this, like perhaps showing a meaningful message in the browser and some documentation on the contract, but for now this quick fix should hopefully prevent deployers from banging their head against the wall.

btw, we don't even seem to be using displayName?