### PR TITLE
EB formatter: fix ACS index support.

### DIFF
--- a/manage-server/src/main/java/manage/format/EngineBlockFormatter.java
+++ b/manage-server/src/main/java/manage/format/EngineBlockFormatter.java
@@ -324,6 +324,7 @@ public class EngineBlockFormatter {
         IntStream.range(0, 10).forEach(i -> {
             String binding = metaDataFields.get("AssertionConsumerService:" + i + ":Binding");
             String location = metaDataFields.get("AssertionConsumerService:" + i + ":Location");
+            String index = metaDataFields.get("AssertionConsumerService:" + i + ":index");
 
             if (hasText(binding) || hasText(location)) {
                 ArrayList<Object> assertionConsumerServiceContainer = (ArrayList<Object>) metadata.computeIfAbsent(
@@ -331,7 +332,7 @@ public class EngineBlockFormatter {
                 Map<String, String> assertionConsumerService = new HashMap<>();
                 putIfHasText("Binding", binding, assertionConsumerService);
                 putIfHasText("Location", location, assertionConsumerService);
-                assertionConsumerService.put("Index", Integer.toString(i));
+                putIfHasText("Index", index, assertionConsumerService);
 
                 assertionConsumerServiceContainer.add(assertionConsumerService);
             }

--- a/manage-server/src/test/resources/push/push.expected.json
+++ b/manage-server/src/test/resources/push/push.expected.json
@@ -39,12 +39,10 @@
         "AssertionConsumerService": [
           {
             "Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-            "Index": "0",
             "Location": "https://acs0"
           },
           {
             "Binding": "urn:oasis:names:tc:SAML:2.0:bindings:URI",
-            "Index": "1",
             "Location": "https://acs1"
           }
         ],
@@ -214,7 +212,6 @@
         "AssertionConsumerService": [
           {
             "Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-            "Index": "0",
             "Location": "https://mujina-sp.test2.surfconext.nl/saml/SSO"
           }
         ],
@@ -284,7 +281,6 @@
         "AssertionConsumerService": [
           {
             "Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-            "Index": "0",
             "Location": "https://serviceregistry.test2.surfconext.nl/simplesaml/module.php/saml/sp/saml2-acs.php/default-sp"
           }
         ],
@@ -352,7 +348,6 @@
         "AssertionConsumerService": [
           {
             "Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-            "Index": "0",
             "Location": "https://serviceregistry.test2.surfconext.nl/simplesaml/module.php/saml/sp/saml2-acs.php/default-sp"
           }
         ],

--- a/manage-server/src/test/resources/push/push_results.json
+++ b/manage-server/src/test/resources/push/push_results.json
@@ -28,15 +28,15 @@
   "metadata" : {
     "AssertionConsumerService" : [ {
       "Binding" : "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-      "Index" : "0",
+      "Index" : "1",
       "Location" : "https://teams.surfconext.nl/Shibboleth.sso/SAML2/POST"
     }, {
       "Binding" : "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact",
-      "Index" : "1",
+      "Index" : "3",
       "Location" : "https://teams.surfconext.nl/Shibboleth.sso/SAML2/Artifact"
     }, {
       "Binding" : "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
-      "Index" : "2",
+      "Index" : "4",
       "Location" : "https://teams.surfconext.nl/Shibboleth.sso/SAML2/ECP"
     } ],
     "NameIDFormat" : "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",


### PR DESCRIPTION
Not the counter i but the actual field "index" should be passed to Engineblock as the Index.