### PR TITLE
Added missing dependency spring-boot-starter-validation

### DIFF
--- a/manage-server/pom.xml
+++ b/manage-server/pom.xml
@@ -64,6 +64,10 @@
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <version>2.0.1.Final</version>


### PR DESCRIPTION
The controllers in Manage use the `@Validated` annotation however, this annotation requires 

```       
<dependency>
    <groupId>org.springframework.boot</groupId>
    <artifactId>spring-boot-starter-validation</artifactId>
</dependency>
```
to work since spring 2.3: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.3.0-M1-Release-Notes