### PR TITLE
Streamline version numbers used for the modules

### DIFF
--- a/manage-gui/pom.xml
+++ b/manage-gui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openconext</groupId>
         <artifactId>manage</artifactId>
-        <version>10.0.0</version>
+        <version>6.0.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/manage-server/pom.xml
+++ b/manage-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.openconext</groupId>
         <artifactId>manage</artifactId>
-        <version>10.0.0</version>
+        <version>6.0.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.openconext</groupId>
     <artifactId>manage</artifactId>
-    <version>10.0.0</version>
+    <version>6.0.8</version>
     <packaging>pom</packaging>
 
     <name>manage</name>


### PR DESCRIPTION
Streamline the parent pom to release the same version as the GUI and Server, so it makes the release process more clear.