### PR TITLE
Add displayName to search algorithm

### DIFF
--- a/manage-server/src/main/java/manage/repository/MetaDataRepository.java
+++ b/manage-server/src/main/java/manage/repository/MetaDataRepository.java
@@ -94,6 +94,7 @@ public class MetaDataRepository {
             orCriterias.add(regex("data.entityid", part));
             this.supportedLanguages.forEach(lang -> {
                 orCriterias.add(regex("data.metaDataFields.name:" + lang, part));
+                orCriterias.add(regex("data.metaDataFields.displayName:" + lang, part));
                 orCriterias.add(regex("data.metaDataFields.keywords:" + lang, part));
                 orCriterias.add(regex("data.metaDataFields.OrganizationName:" + lang, part));
             });


### PR DESCRIPTION
Maybe it's dependent on the way I register my SPs, but sometimes the name and displayName are completely different..

For example, for the `name` we usually have a more technical name like "Sharepoint customer X" and then the `displayName` would be a user-friendly name like "Samenwerkruimten"..