### PR TITLE
Added authorisations for controller endpoints

### DIFF
--- a/manage-server/src/main/java/manage/control/DatabaseController.java
+++ b/manage-server/src/main/java/manage/control/DatabaseController.java
@@ -18,6 +18,7 @@ import org.springframework.core.env.Profiles;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -129,6 +130,7 @@ public class DatabaseController {
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/client/playground/pushPreview")
     public Map<String, Map<String, Map<String, Object>>> pushPreview() {
         EngineBlockFormatter formatter = new EngineBlockFormatter();

--- a/manage-server/src/main/java/manage/control/ExportController.java
+++ b/manage-server/src/main/java/manage/control/ExportController.java
@@ -2,6 +2,7 @@ package manage.control;
 
 import manage.model.MetaData;
 import manage.service.ExporterService;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,6 +19,7 @@ public class ExportController {
         this.exporterService = exporterService;
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping(value = "/client/export")
     public Map<String, Object> export(@RequestBody MetaData metaData) throws IOException {
         return exporterService.export(metaData);

--- a/manage-server/src/main/java/manage/control/MetaDataController.java
+++ b/manage-server/src/main/java/manage/control/MetaDataController.java
@@ -65,17 +65,20 @@ public class MetaDataController {
 
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/client/template/{type}")
     public MetaData template(@PathVariable("type") String type) {
         Map<String, Object> data = metaDataAutoConfiguration.metaDataTemplate(type);
         return new MetaData(type, data);
     }
 
+    @PreAuthorize("hasAnyRole('USER', 'READ')")
     @GetMapping({"/client/metadata/{type}/{id}", "/internal/metadata/{type}/{id}"})
     public MetaData get(@PathVariable("type") String type, @PathVariable("id") String id) {
         return metaDataService.getMetaDataAndValidate(type, id);
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/client/metadata/configuration")
     public List<Map<String, Object>> configuration() {
         return metaDataAutoConfiguration.schemaRepresentations();
@@ -102,6 +105,7 @@ public class MetaDataController {
         return metaDataService.doPut(metaData, federatedUser.getUid(), false);
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/client/metadata/stats")
     public List<StatsEntry> stats() {
         return metaDataRepository.stats();
@@ -137,6 +141,7 @@ public class MetaDataController {
         return Collections.singletonMap("deleted", deleted);
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping(value = "/client/count/feed")
     public Map<String, Long> countFeed() {
         long count = this.metaDataRepository.countAllImportedServiceProviders();
@@ -169,12 +174,14 @@ public class MetaDataController {
         return metaDataService.doPut(metaData, apiUser.getName(), !apiUser.getScopes().contains(TEST));
     }
 
+    @PreAuthorize("hasRole('READ')")
     @GetMapping("/internal/sp-metadata/{id}")
     public String exportXml(@PathVariable("id") String id) throws IOException {
         MetaData metaData = metaDataService.getMetaDataAndValidate(EntityType.SP.getType(), id);
         return exporterService.exportToXml(metaData);
     }
 
+    @PreAuthorize("hasRole('READ')")
     @GetMapping(value = "/internal/xml/metadata/{type}/{id}", produces = "text/xml")
     public String exportMetadataXml(@PathVariable("type") String type,
                                     @PathVariable("id") String id) throws IOException {
@@ -337,6 +344,7 @@ public class MetaDataController {
         return metaDataService.restoreRevision(revisionRestore, federatedUser);
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/client/revisions/{type}/{parentId}")
     public List<MetaData> revisions(@PathVariable("type") String type,
                                     @PathVariable("parentId") String parentId) {
@@ -344,6 +352,7 @@ public class MetaDataController {
         return metaDataRepository.revisions(type.concat(REVISION_POSTFIX), parentId);
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/client/autocomplete/{type}")
     public Map<String, List<Map>> autoCompleteEntities(@PathVariable("type") String type,
                                                        @RequestParam("query") String query) {
@@ -351,17 +360,20 @@ public class MetaDataController {
         return metaDataService.autoCompleteEntities(type, query);
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/client/whiteListing/{type}")
     public List<Map> whiteListing(@PathVariable("type") String type, @RequestParam(value = "state") String state) {
         return metaDataRepository.whiteListing(type, state);
     }
 
+    @PreAuthorize("hasAnyRole('USER', 'READ')")
     @PostMapping({"/client/uniqueEntityId/{type}", "/internal/uniqueEntityId/{type}"})
     public List<Map> uniqueEntityId(@PathVariable("type") String type, @RequestBody Map<String, Object> properties) {
         String entityId = (String) properties.get("entityid");
         return metaDataService.uniqueEntityId(type, entityId);
     }
 
+    @PreAuthorize("hasAnyRole('USER', 'READ')")
     @PostMapping({"/client/search/{type}", "/internal/search/{type}"})
     public List<Map> searchEntities(@PathVariable("type") String type,
                                     @RequestBody Map<String, Object> properties,
@@ -370,6 +382,7 @@ public class MetaDataController {
         return metaDataService.searchEntityByType(type, properties, nested);
     }
 
+    @PreAuthorize("hasAnyRole('USER', 'READ')")
     @GetMapping({"/client/rawSearch/{type}", "/internal/rawSearch/{type}"})
     public List<MetaData> rawSearch(@PathVariable("type") String type, @RequestParam("query") String query)
             throws UnsupportedEncodingException {
@@ -377,6 +390,7 @@ public class MetaDataController {
         return metaDataService.retrieveRawSearch(type, query);
     }
 
+    @PreAuthorize("hasAnyRole('USER', 'READ')")
     @PostMapping({"/client/recent-activity", "/internal/recent-activity"})
     public List<MetaData> recentActivity(@RequestBody(required = false) Map<String, Object> properties) {
         return metaDataService.retrieveRecentActivity(properties);

--- a/manage-server/src/main/java/manage/control/ScopeController.java
+++ b/manage-server/src/main/java/manage/control/ScopeController.java
@@ -19,6 +19,7 @@ import org.springframework.data.mongodb.core.query.BasicQuery;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -60,16 +61,19 @@ public class ScopeController {
         this.supportedLanguages = Stream.of(supportedLanguages.split(",")).map(String::trim).collect(toList());
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping({"/client/scopes_languages"})
     public List<String> supportedLanguages() {
         return supportedLanguages;
     }
 
+    @PreAuthorize("hasAnyRole('USER', 'READ')")
     @GetMapping({"/client/scopes", "/internal/scopes"})
     public List<Scope> allScopes() {
         return scopeRepository.findAll();
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping({"/client/scopes/{id}"})
     public boolean delete(@PathVariable("id") String id) throws JsonProcessingException {
         Scope scope = scopeById(id);
@@ -84,16 +88,19 @@ public class ScopeController {
         return scope;
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping(value = "/client/fetch/scopes", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<String> fetchValues() {
         return scopeRepository.findAll().stream().map(Scope::getName).collect(Collectors.toList());
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping({"/client/scopes/{id}"})
     public Scope get(@PathVariable("id") String id) {
         return scopeById(id);
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/client/inuse/scopes")
     public List<MetaData> scopesInUse(@RequestParam(value = "scopes") String scopes) {
         String scopesIn = Stream.of(scopes.split(",")).map(s -> String.format("\"%s\"", s.trim())).collect(Collectors.joining(","));
@@ -101,6 +108,7 @@ public class ScopeController {
         return mongoTemplate.find(new BasicQuery(query), MetaData.class, RS.getType());
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PutMapping({"/client/scopes"})
     public Scope update(@RequestBody Scope scope) throws JsonProcessingException {
         Scope previous = scopeById(scope.getId());
@@ -120,6 +128,7 @@ public class ScopeController {
         }
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping({"/client/scopes"})
     public Scope save(@RequestBody Scope scope) {
         LOG.info("Saving scope {}", scope);

--- a/manage-server/src/main/java/manage/control/SystemController.java
+++ b/manage-server/src/main/java/manage/control/SystemController.java
@@ -71,6 +71,7 @@ public class SystemController {
         return databaseController.doPush();
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/client/playground/validate")
     public Map<String, Object> validate(FederatedUser federatedUser) {
         if (!federatedUser.featureAllowed(Features.VALIDATION)) {
@@ -110,6 +111,7 @@ public class SystemController {
         });
     }
 
+    @PreAuthorize("hasAnyRole('USER', 'READ')")
     @GetMapping({"/client/playground/orphans", "/internal/playground/orphans"})
     public List<OrphanMetaData> orphans() {
         return Stream.of(EntityType.values())

--- a/manage-server/src/main/java/manage/control/UserController.java
+++ b/manage-server/src/main/java/manage/control/UserController.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -38,22 +39,26 @@ public class UserController {
     @Value("${gui.disclaimer.content}")
     private String disclaimerContent;
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/client/users/me")
     public FederatedUser me(FederatedUser federatedUser) {
         return federatedUser;
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/client/users/ping")
     public Map<String, String> ping() {
         return Collections.singletonMap("Ping", "Ok");
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/client/users/logout")
     public void logout(HttpServletRequest request) {
         request.getSession().invalidate();
         SecurityContextHolder.clearContext();
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/client/users/error")
     public void error(@RequestBody Map<String, Object> payload, FederatedUser federatedUser) throws
             JsonProcessingException, UnknownHostException {

--- a/manage-server/src/main/java/manage/control/ValidationController.java
+++ b/manage-server/src/main/java/manage/control/ValidationController.java
@@ -21,6 +21,7 @@ import org.passay.CharacterRule;
 import org.passay.EnglishCharacterData;
 import org.passay.PasswordGenerator;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -78,6 +79,7 @@ public class ValidationController {
         return Arrays.asList(lowerCaseRule, upperCaseRule, digitRule);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/client/validation")
     public boolean validation(@Validated @RequestBody Validation validation) {
         return !validators.computeIfAbsent(validation.getType(), key -> {
@@ -85,6 +87,7 @@ public class ValidationController {
         }).validate(validation.getValue()).isPresent();
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping(value = "/client/secret", produces = MediaType.APPLICATION_JSON_VALUE)
     public Map<String, String> secret() {
         return Collections.singletonMap("secret", passwordGenerator.generatePassword(36, rules));


### PR DESCRIPTION
Hi all,

We have made changes to some back-end Controller endpoints to require the correct authorisation. Only endpoints that did not have an authorisation check before were updated. The following principle was used to determine the authorisation:

If it's a /client endpoint:
- GET endpoints will check for 'USER'
- POST, PUT endpoints will check for 'ADMIN'

If it's an /internal endpoint
- GET endpoints will check for 'READ'
(POST, PUT have not been found updated as the authorisation check is already present)

This change improves the security by explicitly requiring authorisation for most (the /disclaimer endpoint has been left untouched since it is called directly in index.html) endpoints, this is especially useful for endpoints available to external applications.

Please let us know if you agree with the approach and feel free to let us know in case of any questions.