### PR TITLE
Fixed authorisation for controller endpoint

### DIFF
--- a/manage-server/src/main/java/manage/control/MetaDataController.java
+++ b/manage-server/src/main/java/manage/control/MetaDataController.java
@@ -396,7 +396,7 @@ public class MetaDataController {
         return metaDataService.retrieveRecentActivity(properties);
     }
 
-    @Secured("WRITE")
+    @Secured("ROLE_WRITE")
     @PutMapping(value = "/internal/connectWithoutInteraction")
     public HttpEntity<HttpStatus> connectWithoutInteraction(@RequestBody Map<String, String> connectionData,
                                                             APIUser apiUser) throws JsonProcessingException {

--- a/manage-server/src/main/java/manage/web/WebSecurityConfigurer.java
+++ b/manage-server/src/main/java/manage/web/WebSecurityConfigurer.java
@@ -49,7 +49,7 @@ import static java.util.stream.Collectors.toList;
  */
 @Configuration
 @EnableWebSecurity
-@EnableGlobalMethodSecurity(prePostEnabled = true)
+@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
 public class WebSecurityConfigurer {
 
     @Autowired

--- a/manage-server/src/test/java/manage/control/MetaDataControllerTest.java
+++ b/manage-server/src/test/java/manage/control/MetaDataControllerTest.java
@@ -1136,6 +1136,29 @@ public class MetaDataControllerTest extends AbstractIntegrationTest {
     }
 
     @Test
+    public void connectValidSpWithoutInteractionInvalidApiUser() {
+        String idpEntityId = "https://idp.test2.surfconext.nl";
+        String spId = "Duis ad do";
+        String spType = "saml20_sp";
+        Map<String, String> connectionData = new HashMap<>();
+        connectionData.put("idpId", idpEntityId);
+        connectionData.put("spId", spId);
+        connectionData.put("spType", spType);
+        connectionData.put("user", "John Doe");
+        connectionData.put("loaLevel", "http://test.surfconext.nl/assurance/loa2");
+
+        given()
+                .auth()
+                .preemptive()
+                .basic("stats", "secret")
+                .header("Content-type", "application/json")
+                .body(connectionData)
+                .put("manage/api/internal/connectWithoutInteraction/")
+                .then()
+                .statusCode(SC_FORBIDDEN);
+    }
+
+    @Test
     public void exportMetadataXml() throws IOException {
         given()
                 .config(newConfig().xmlConfig(xmlConfig()


### PR DESCRIPTION
Hi all,

Related to the previous PR on adding authorisations for controller endpoints (https://github.com/OpenConext/OpenConext-manage/pull/73), this one focuses on one specific endpoint which was not returning a forbidden response when the API user did not have the right authorisation. This has been resolved and a unit test has been added to verify this.

@oharsta please also note: this implementation should most likely be reworked with the coming generic solution in WebSecurityConfigurer.java that you already mentioned. 