### PR TITLE
Extended duplicate entity id validation

### DIFF
--- a/manage-server/src/main/java/manage/service/MetaDataService.java
+++ b/manage-server/src/main/java/manage/service/MetaDataService.java
@@ -356,10 +356,12 @@ public class MetaDataService {
         return revision;
     }
 
-    private void checkForDuplicateEntityId(MetaData metData, boolean isNew) {
-        String entityid = (String) metData.getData().get("entityid");
-        List<Map> result = uniqueEntityId(metData.getType(), entityid);
-        if ((isNew && !CollectionUtils.isEmpty(result)) || (!isNew && result.size() > 1)) {
+    private void checkForDuplicateEntityId(MetaData metaData, boolean isNew) {
+        String entityid = (String) metaData.getData().get("entityid");
+        List<Map> matchingEntities = uniqueEntityId(metaData.getType(), entityid);
+        if ((isNew && !CollectionUtils.isEmpty(matchingEntities)) ||
+                (matchingEntities.size() == 1 && !matchingEntities.get(0).get("_id").equals(metaData.getId())) ||
+                matchingEntities.size() > 1) {
             throw new DuplicateEntityIdException(entityid);
         }
     }


### PR DESCRIPTION
Hi all,

We have extended the validation of the duplicate entity id check so that it is now the following
- If it is new request and if any entities with that entity id are found
- If one matching record is found and if the ids of the entities do not match   (added)
- if matching records are more than 1

If any of these conditions are met then a duplicate entity id exception is thrown.

