### PR TITLE
Resolve XSS vulnerability when deleting entity

### DIFF
--- a/manage-gui/src/components/ConfirmationDialog.jsx
+++ b/manage-gui/src/components/ConfirmationDialog.jsx
@@ -28,7 +28,7 @@ export default function ConfirmationDialog({
                     <p>{I18n.t("confirmation_dialog.leavePageSub")}</p>
                 </section> :
                 <section className="dialog-content">
-                    <h2 dangerouslySetInnerHTML={{__html: question}}></h2>
+                    <h2>{question}</h2>
                 </section>}
             <section className="dialog-buttons">
                 <a className="button" onClick={e => {

--- a/manage-gui/src/components/ConfirmationDialog.scss
+++ b/manage-gui/src/components/ConfirmationDialog.scss
@@ -39,6 +39,7 @@
     .dialog-content {
       margin-top: auto;
       text-align: center;
+      white-space: pre-line;
 
       h2 {
         padding: 25px;

--- a/manage-gui/src/locale/en.js
+++ b/manage-gui/src/locale/en.js
@@ -92,7 +92,7 @@ I18n.translations.en = {
         },
         required: "{{name}} is required",
         extraneous: "{{name}} is an unknown / extraneous key. Remove it as this can not be saved.",
-        deleteConfirmation: "Are you sure you want to delete {{name}}?<br/><br/>You can optionally specify the reason for deletion in the revision notes before pressing the 'delete' button.",
+        deleteConfirmation: "Are you sure you want to delete {{name}}?\n\nYou can optionally specify the reason for deletion in the revision notes before pressing the 'delete' button.",
         errors: "There are validation errors:"
 
     },


### PR DESCRIPTION
Hi all,

Recently a pentest was conducted of our OpenConext setup from which the following vulnerability was identified: removing an entity whose name contains a script will run when the "DELETE" button is clicked. We have resolved this vulnerability with these changes. 

Also first confirmed with @oharsta that submitting via this manner was agreeable.