### PR TITLE
Import NameIDFormat from xml

### DIFF
--- a/manage-server/src/main/java/manage/format/MetaDataFeedParser.java
+++ b/manage-server/src/main/java/manage/format/MetaDataFeedParser.java
@@ -221,6 +221,9 @@ public class MetaDataFeedParser {
                                 }
                             }
                             break;
+                        case "NameIDFormat":
+                            metaDataFields.put("NameIDFormat", reader.getElementText());
+                            break;
                         case "SingleSignOnService":
                             if (!inCorrectEntityDescriptor || isSp) {
                                 break;

--- a/manage-server/src/test/resources/json/expected_imported_metadata_edugain.json
+++ b/manage-server/src/test/resources/json/expected_imported_metadata_edugain.json
@@ -60,6 +60,7 @@
     "AssertionConsumerService:1:Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact",
     "AssertionConsumerService:1:Location": "https://wayf.nikhef.nl/sso/module.php/saml/sp/saml2-acs.php/default-sp",
     "AssertionConsumerService:1:index": 2,
+    "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
     "OrganizationDisplayName:en": "Nikhef",
     "OrganizationDisplayName:nl": "Nikhef",
     "OrganizationName:en": "Nikhef - Dutch National Institute for Subatomic Physics",

--- a/manage-server/src/test/resources/json/expected_imported_metadata_saml20_idp.json
+++ b/manage-server/src/test/resources/json/expected_imported_metadata_saml20_idp.json
@@ -1,4 +1,5 @@
 {
+  "NameIDFormat" : "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
   "OrganizationDisplayName:en" : "SURFdropjes Beta",
   "OrganizationDisplayName:nl" : "SURFdropjes Beta",
   "OrganizationName:en" : "SURFdropjes Beta",

--- a/manage-server/src/test/resources/json/expected_imported_metadata_saml20_sp.json
+++ b/manage-server/src/test/resources/json/expected_imported_metadata_saml20_sp.json
@@ -8,6 +8,7 @@
   "AssertionConsumerService:2:Binding" : "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
   "AssertionConsumerService:2:Location" : "https://teams.surfconext.nl/Shibboleth.sso/SAML2/ECP",
   "AssertionConsumerService:2:index" : 2,
+  "NameIDFormat" : "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
   "OrganizationDisplayName:en" : "SURFnet",
   "OrganizationDisplayName:nl" : "SURFnet",
   "OrganizationName:en" : "SURFnet BV",


### PR DESCRIPTION
Currently the NameIDFormat is ignored when metadata is loaded from xml (with manual or url import):
`   
 <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
`

When a Service Provider connects to engineblock we want to ensure that they have configured a valid NameIDFormat.
