### PR TITLE
Retrieve entity states from configuration

### DIFF
--- a/manage-gui/src/components/metadata/Connection.jsx
+++ b/manage-gui/src/components/metadata/Connection.jsx
@@ -33,6 +33,7 @@ export default class Connection extends React.PureComponent {
     const isRelyingParty = type === "oidc10_rp";
     const isResourceServer = type === "oauth20_rs";
     const entityIdFormat = this.props.configuration.properties.entityid.format;
+    const states = this.props.configuration.properties.state.enum;
 
     const logo = data.metaDataFields["logo:0:url"];
     const name =
@@ -105,6 +106,7 @@ export default class Connection extends React.PureComponent {
                 <SelectState
                   onChange={this.onChange("data.state")}
                   state={data.state}
+                  states={states}
                   disabled={guest}
                 />
               </td>

--- a/manage-gui/src/components/metadata/SelectState.jsx
+++ b/manage-gui/src/components/metadata/SelectState.jsx
@@ -5,8 +5,6 @@ import {Select} from "./../../components";
 import I18n from "i18n-js";
 import "./SelectState.scss";
 
-const states = ["prodaccepted", "testaccepted"];
-
 export default class SelectState extends React.PureComponent {
 
   renderOption = option => {
@@ -20,7 +18,7 @@ export default class SelectState extends React.PureComponent {
   };
 
   render() {
-    const {onChange, state, disabled} = this.props;
+    const {onChange, state, states, disabled} = this.props;
     const options = states.map(s => {
       return {value: s, label: I18n.t(`metadata.${s}`)};
     });
@@ -45,5 +43,6 @@ export default class SelectState extends React.PureComponent {
 SelectState.propTypes = {
   onChange: PropTypes.func.isRequired,
   state: PropTypes.string.isRequired,
+  states: PropTypes.array.isRequired,
   disabled: PropTypes.bool
 };


### PR DESCRIPTION
Hi all,

We have made some changes so that the possible states for an entity (testaccepted, prodaccepted) are based on the configuration set for that particular entity. For example, the Service Provider state options will now be based on the configuration set in saml20_sp.schema.json.

For us, this makes it possible to introduce a state that is only applicable to a certain entity while not impacting the other entities.
This change should not impact the default behaviour of Manage as there is only testaccepted and prodaccepted for all entities.