### PR TITLE
Weaker strength for Resource Servers / Relaying parties secrets

### DIFF
--- a/manage-gui/src/components/form/Password.jsx
+++ b/manage-gui/src/components/form/Password.jsx
@@ -6,6 +6,8 @@ import {secret} from "../../api";
 import CopyToClipboard from "react-copy-to-clipboard";
 import ReactTooltip from "react-tooltip";
 
+const minLength = 12;
+
 export default class Password extends React.PureComponent {
 
   state = {
@@ -59,8 +61,6 @@ export default class Password extends React.PureComponent {
 
   handleSave() {
     const {value} = this.state;
-    const {minLength} = this.props;
-
     if (value && minLength && value.length < minLength) {
       this.setState({showLengthWarning: true});
       this.props.hasError(this.props.name, true);
@@ -133,7 +133,7 @@ export default class Password extends React.PureComponent {
 
   render() {
     const {value, showSaveWarning, showLengthWarning, copied} = this.state;
-    const {hasFormatError, onChange, minLength, hasError, ...rest} = this.props;
+    const {hasFormatError, onChange, hasError, ...rest} = this.props;
 
     const disabled = this.state.disabled || this.props.disabled;
 

--- a/manage-server/src/main/java/manage/hook/MetaDataHookConfiguration.java
+++ b/manage-server/src/main/java/manage/hook/MetaDataHookConfiguration.java
@@ -19,7 +19,7 @@ public class MetaDataHookConfiguration {
 
         EmptyRevisionHook emptyRevisionHook = new EmptyRevisionHook(metaDataAutoConfiguration);
         EntityIdReconcilerHook entityIdReconcilerHook = new EntityIdReconcilerHook(metaDataRepository);
-        SecretHook secretHook = new SecretHook();
+        SecretHook secretHook = new SecretHook(metaDataAutoConfiguration);
         TypeSafetyHook typeSafetyHook = new TypeSafetyHook(metaDataAutoConfiguration);
         EntityIdConstraintsHook entityIdConstraintsHook = new EntityIdConstraintsHook(metaDataRepository);
         OidcValidationHook validationHook = new OidcValidationHook(metaDataAutoConfiguration);

--- a/manage-server/src/main/resources/metadata_configuration/oauth20_rs.schema.json
+++ b/manage-server/src/main/resources/metadata_configuration/oauth20_rs.schema.json
@@ -96,7 +96,7 @@
         "secret": {
           "type": "string",
           "format": "password",
-          "info": "The secret of this Resource Server for authentication purposes."
+          "info": "The secret of this Resource Server for authentication purposes - minimal length 12 characters."
         },
         "scopes": {
           "type": "array",

--- a/manage-server/src/main/resources/metadata_configuration/oidc10_rp.schema.json
+++ b/manage-server/src/main/resources/metadata_configuration/oidc10_rp.schema.json
@@ -476,7 +476,7 @@
         "secret": {
           "type": "string",
           "format": "password",
-          "info": "The secret of this Relying Party for authentication purposes."
+          "info": "The secret of this Relying Party for authentication purposes - minimal length 12 characters."
         },
         "clientSecretJWT": {
           "type": "string",

--- a/manage-server/src/test/java/manage/hook/SecretHookTest.java
+++ b/manage-server/src/test/java/manage/hook/SecretHookTest.java
@@ -1,23 +1,28 @@
 package manage.hook;
 
+import manage.model.EntityType;
 import manage.model.MetaData;
 import org.junit.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static java.util.Collections.emptyMap;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class SecretHookTest {
 
-    private SecretHook subject = new SecretHook();
+    private final SecretHook subject = new SecretHook();
+    private final Pattern bcryptPattern = Pattern.compile("\\A\\$2(a|y|b)?\\$(\\d\\d)\\$[./0-9A-Za-z]{53}");
 
     @Test
     public void appliesForMetaData() {
-        assertEquals(true, subject.appliesForMetaData(new MetaData("oidc10_rp", emptyMap())));
-        assertEquals(true, subject.appliesForMetaData(new MetaData("oauth20_rs", emptyMap())));
-        assertEquals(false, subject.appliesForMetaData(new MetaData("nope", emptyMap())));
+        assertTrue(subject.appliesForMetaData(new MetaData("oidc10_rp", emptyMap())));
+        assertTrue(subject.appliesForMetaData(new MetaData("oauth20_rs", emptyMap())));
+        assertFalse(subject.appliesForMetaData(new MetaData("nope", emptyMap())));
     }
 
     @Test
@@ -29,7 +34,7 @@ public class SecretHookTest {
     @Test
     public void prePut() {
         MetaData metaData = subject.prePut(null, metaData("secret"));
-        assertEquals(true, subject.isBCryptEncoded((String) metaData.metaDataFields().get("secret")));
+        assertTrue(subject.isBCryptEncoded((String) metaData.metaDataFields().get("secret")));
 
         String secret = (String) metaData.metaDataFields().get("secret");
         metaData = subject.prePut(null, metaData);
@@ -41,13 +46,15 @@ public class SecretHookTest {
     @Test
     public void prePost() {
         MetaData metaData = subject.prePost(metaData("secret"));
-        assertEquals(true, subject.isBCryptEncoded((String) metaData.metaDataFields().get("secret")));
+        String encodedPassword = (String) metaData.metaDataFields().get("secret");
 
-        String secret = (String) metaData.metaDataFields().get("secret");
+        assertTrue(subject.isBCryptEncoded(encodedPassword));
+        assertEquals(10, this.getStrength(encodedPassword));
+
         metaData = subject.prePost(metaData);
 
         String unchangedSecret = (String) metaData.metaDataFields().get("secret");
-        assertEquals(secret, unchangedSecret);
+        assertEquals(encodedPassword, unchangedSecret);
     }
 
     @Test
@@ -58,15 +65,37 @@ public class SecretHookTest {
 
     @Test
     public void isBCryptEncoded() {
-        assertEquals(false, subject.isBCryptEncoded("secret"));
+        assertFalse(subject.isBCryptEncoded("secret"));
+    }
+
+    @Test
+    public void resourceServerWeakerStrength() {
+        MetaData metaData = subject.prePost(metaData("secret", EntityType.RS));
+        String encodedPassword = (String) metaData.metaDataFields().get("secret");
+
+        assertTrue(subject.isBCryptEncoded(encodedPassword));
+        assertEquals(5, this.getStrength(encodedPassword));
+    }
+
+    private int getStrength(String encodedPassword) {
+        Matcher matcher = this.bcryptPattern.matcher(encodedPassword);
+        boolean matches = matcher.matches();
+
+        assertTrue(matches);
+
+        return Integer.parseInt(matcher.group(2));
     }
 
     private MetaData metaData(String secret) {
+        return this.metaData(secret, EntityType.RP);
+    }
+
+    private MetaData metaData(String secret, EntityType entityType) {
         Map<String, Object> data = new HashMap<>();
         Map<String, Object> metaDataFields = new HashMap<>();
         data.put("metaDataFields", metaDataFields);
 
         metaDataFields.put("secret", secret);
-        return new MetaData("oidc10_rp", data);
+        return new MetaData(entityType.getType(), data);
     }
 }

--- a/manage-server/src/test/resources/json/meta_data_seed.json
+++ b/manage-server/src/test/resources/json/meta_data_seed.json
@@ -498,7 +498,7 @@
       "manipulation": "PHP code OIDC10_RP",
       "metaDataFields": {
         "name:en": "OIDC SP",
-        "secret": "secret",
+        "secret": "secret1234567890",
         "redirectUrls": [
           "http://localhost:8080/redirect1",
           "http://localhost:8080/redirect2"
@@ -531,7 +531,7 @@
       "state": "prodaccepted",
       "metaDataFields": {
         "name:en": "OIDC ResourceServer",
-        "secret": "secret",
+        "secret": "secret1234567890",
         "scopes": [
           "openid",
           "groups"


### PR DESCRIPTION
The default BCrypt strength of 10 decreases the performance of the Introspection endpoint with ~60ms. Under heavy load this is becoming a bottle-neck. The Hook to encrypt plain text secrets now used a strength of 5 for Resource Server secrets.