### PR TITLE
Hide password field in Manage API

### DIFF
--- a/manage-server/src/main/java/manage/control/UserController.java
+++ b/manage-server/src/main/java/manage/control/UserController.java
@@ -2,6 +2,7 @@ package manage.control;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import manage.model.dto.FederatedUserDto;
 import manage.shibboleth.FederatedUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,8 +42,8 @@ public class UserController {
 
     @PreAuthorize("hasRole('USER')")
     @GetMapping("/client/users/me")
-    public FederatedUser me(FederatedUser federatedUser) {
-        return federatedUser;
+    public FederatedUserDto me(FederatedUser federatedUser) {
+        return FederatedUserDto.fromFederatedUser(federatedUser);
     }
 
     @PreAuthorize("hasRole('USER')")

--- a/manage-server/src/main/java/manage/model/dto/FederatedUserDto.java
+++ b/manage-server/src/main/java/manage/model/dto/FederatedUserDto.java
@@ -1,0 +1,72 @@
+package manage.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import manage.conf.Features;
+import manage.conf.Product;
+import manage.conf.Push;
+import manage.shibboleth.FederatedUser;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FederatedUserDto {
+
+    private String username;
+
+    private Set<GrantedAuthority> authorities;
+
+    private boolean accountNonExpired;
+
+    private boolean accountNonLocked;
+
+    private boolean credentialsNonExpired;
+
+    private boolean enabled;
+
+    private String uid;
+
+    private String displayName;
+
+    private String schacHomeOrganization;
+
+    private List<Features> featureToggles;
+
+    private Product product;
+
+    private Push push;
+
+    private String name;
+
+    private boolean isAPIUser;
+
+    private boolean isGuest;
+
+    public static FederatedUserDto fromFederatedUser(FederatedUser federatedUser) {
+        return null == federatedUser ? null : new FederatedUserDto(
+                federatedUser.getUsername(),
+                new HashSet<>(federatedUser.getAuthorities()),
+                federatedUser.isAccountNonExpired(),
+                federatedUser.isAccountNonLocked(),
+                federatedUser.isCredentialsNonExpired(),
+                federatedUser.isEnabled(),
+                federatedUser.getUid(),
+                federatedUser.getDisplayName(),
+                federatedUser.getSchacHomeOrganization(),
+                federatedUser.getFeatureToggles(),
+                federatedUser.getProduct(),
+                federatedUser.getPush(),
+                federatedUser.getName(),
+                federatedUser.isAPIUser(),
+                federatedUser.isGuest()
+        );
+    }
+}

--- a/manage-server/src/test/java/manage/control/UserControllerTest.java
+++ b/manage-server/src/test/java/manage/control/UserControllerTest.java
@@ -1,0 +1,36 @@
+package manage.control;
+
+import manage.AbstractIntegrationTest;
+import manage.conf.Product;
+import manage.conf.Push;
+import manage.shibboleth.FederatedUser;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static io.restassured.RestAssured.given;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.junit.Assert.assertFalse;
+
+public class UserControllerTest extends AbstractIntegrationTest {
+
+    @Test
+    public void checkPasswordNotPresentInAccount() {
+        Product mockProduct = new Product("OpenConext", "Manage", "https://feed.nl", true);
+        Push mockPush = new Push("https://engine-url.nl", "Engineblock", "https://oidc-url.nl", "OIDC", false);
+        FederatedUser mockUser = new FederatedUser("uid", "displayName", "org",
+                Collections.emptyList(), Collections.emptyList(), mockProduct, mockPush);
+
+        String result = given()
+                .when()
+                .body(mockUser)
+                .header("Content-type", "application/json")
+                .get("manage/api/client/users/me")
+                .then()
+                .statusCode(SC_OK)
+                .extract().body().asString();
+
+        assertFalse(result.contains("password"));
+    }
+
+}


### PR DESCRIPTION
Hi everyone,

In this PR we share the changes related to a finding from the recent pentest namely removing the presence of the password field for the user object returned from the API.
This field was never filled but the recommendation was to remove the field altogether. Please let us know if you agree with the approach.