### PR TITLE
User logout permission in Manage API

### DIFF
--- a/manage-server/src/main/java/manage/control/UserController.java
+++ b/manage-server/src/main/java/manage/control/UserController.java
@@ -51,7 +51,7 @@ public class UserController {
         return Collections.singletonMap("Ping", "Ok");
     }
 
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
     @DeleteMapping("/client/users/logout")
     public void logout(HttpServletRequest request) {
         request.getSession().invalidate();


### PR DESCRIPTION
Hi everyone,

This PR relates to the recent pentest, where a remark was made that according to the API permissions only admins could use the logout endpoint. Therefore we changed permission for the user logout endpoint such that users without the ADMIN role are also able to use it.
Please let us know if you agree with this change. 