### PR TITLE
Update Spring Boot and rest-assured, added Dependency Check Maven

### DIFF
--- a/manage-server/pom.xml
+++ b/manage-server/pom.xml
@@ -151,19 +151,19 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>4.5.0</version>
+            <version>${rest-assured.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>json-path</artifactId>
-            <version>4.5.0</version>
+            <version>${rest-assured.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>xml-path</artifactId>
-            <version>4.5.0</version>
+            <version>${rest-assured.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.7.6</version>
     </parent>
 
     <modules>
@@ -25,6 +25,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>11</java.version>
+        <dependency-check-maven.version>7.3.2</dependency-check-maven.version>
+        <rest-assured.version>5.3.0</rest-assured.version>
     </properties>
 
     <build>
@@ -32,7 +34,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.6.3</version>
+                <version>2.7.6</version>
             </plugin>
             <plugin>
                 <groupId>pl.project13.maven</groupId>
@@ -98,6 +100,35 @@
             </extension>
         </extensions>
     </build>
+
+    <profiles>
+        <profile>
+            <id>security-updates</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>${dependency-check-maven.version}</version>
+                        <configuration>
+                            <format>ALL</format>
+                            <failBuildOnCVSS>8</failBuildOnCVSS>
+                            <suppressionFile>suppressions.xml</suppressionFile>
+                            <failBuildOnAnyVulnerability>false</failBuildOnAnyVulnerability>
+                            <mavenSettingsProxyId>kenproxy</mavenSettingsProxyId>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>aggregate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <distributionManagement>
         <repository>

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+
+</suppressions>


### PR DESCRIPTION
This PR updates Spring Boot to the latest 2.x version (2.7.6) and rest-assured to the latest version (5.3.0). Also, the Dependency Check Maven is introduced, which can invoked by enabling the security-updates profiles, such as:

mvn clean install -P security-updates -DskipTests=true -B

See [OpenConext-SSO-Notification](https://github.com/OpenConext/OpenConext-SSO-Notification) for an example to periodically invoke a dependency check pipeline.