### PR TITLE
Inverse logo logic: only show SURFconext if it's positively SURFconext

### DIFF
--- a/manage-gui/src/components/Header.jsx
+++ b/manage-gui/src/components/Header.jsx
@@ -44,7 +44,7 @@ export default class Header extends React.PureComponent {
         if (isEmpty(currentUser)) {
             currentUser = {product: {}}
         }
-        const logo = currentUser.product.organization === "OpenConext" ? logoOpenConext : logoSurfConext;
+        const logo = currentUser.product.organization.startsWith('SURFconext') ? logoSurfConext : logoOpenConext;
         return (
             <div className="header-container">
                 <div className="header">


### PR DESCRIPTION
If you change the product name from OpenConext to ExampleConext, I do not expect the logo to change to SURFconext but instead to remain OpenConext (or be replaced by the deployer).