### PR TITLE
Automated metadata refresh

### DIFF
--- a/manage-gui/src/components/metadata/AutoRefresh.jsx
+++ b/manage-gui/src/components/metadata/AutoRefresh.jsx
@@ -1,0 +1,138 @@
+import React from "react";
+
+import "./AutoRefresh.scss";
+import PropTypes from "prop-types";
+import CheckBox from "../CheckBox";
+import I18n from "i18n-js";
+import {copyToClip, isEmpty} from "../../utils/Utils";
+
+export default class AutoRefresh extends React.PureComponent {
+
+    constructor(props) {
+        super(props);
+        const {metadataAutoRefresh, defaultAutoRefresh} = props;
+        this.state = {
+            addInput: false,
+            keyForNewInput: undefined,
+            value: "",
+            newArpAttributeAddedKey: undefined,
+            copiedToClipboardClassName: ""
+        };
+        // Since auto refresh is completely optional and can be null, initialize a default for the auto refresh configuration
+        if (!metadataAutoRefresh) {
+            this.props.onChange("data.autoRefresh", { ...defaultAutoRefresh });
+        }
+    }
+
+    onChange = (name, value) => {
+        const cleansedName = `data.autoRefresh.fields.${name}`;
+        this.props.onChange(cleansedName, value, true);
+    };
+
+    autoRefreshEnabled = e => {
+        const enableAutoRefresh = e.target.checked;
+        if (!enableAutoRefresh) {
+            this.props.onChange(["data.autoRefresh.enabled", "data.autoRefresh.fields"], [enableAutoRefresh, {}]);
+        } else {
+            this.props.onChange("data.autoRefresh.enabled", enableAutoRefresh);
+        }
+    };
+
+    autoRefreshAllowAll = e => {
+        const autoRefreshAllowAll = e.target.checked;
+        this.props.onChange(["data.autoRefresh.allowAll", "data.autoRefresh.fields"], [autoRefreshAllowAll, {}]);
+    };
+
+    copyToClipboard = () => {
+        copyToClip("auto-refresh-fields-printable");
+        this.setState({copiedToClipboardClassName: "copied"});
+        setTimeout(() => this.setState({copiedToClipboardClassName: ""}), 5000);
+    };
+
+    sortFieldKeys = (configField, attributes) => (aKey, bKey) => {
+        const aEnabled = !isEmpty(attributes[aKey]);
+        const bEnabled = !isEmpty(attributes[bKey]);
+
+        if (aEnabled && !bEnabled) {
+            return -1;
+        }
+        if (!aEnabled && bEnabled) {
+            return 1;
+        }
+        return aKey.localeCompare(bKey);
+    };
+
+    renderRefreshFieldsTable = (autoRefresh, autoRefreshConfiguration, guest) => {
+        const autoRefreshFields = autoRefreshConfiguration.properties.fields.properties;
+        const fieldKeys = Object.keys(autoRefreshFields);
+        fieldKeys.sort(this.sortFieldKeys(autoRefreshFields, autoRefresh.fields));
+
+        const headers = ["name", "enabled"];
+
+        return <table className="auto-refresh-fields">
+            <thead>
+            <tr>
+                {headers.map(td => <th className={td} key={td}>{I18n.t(`auto_refresh.headers.${td}`)}</th>)}
+            </tr>
+            </thead>
+            <tbody>
+            {fieldKeys.map((fieldKey) =>
+                <tr key={fieldKey}>
+                    <td className="field">{fieldKey}</td>
+                    <td className="value">
+                        <CheckBox name={fieldKey}
+                                  value={autoRefresh.fields[fieldKey] ?? false}
+                                  readOnly={guest || autoRefresh.allowAll || !autoRefresh.enabled}
+                                  onChange={e => this.onChange(fieldKey, e.target.checked)}/>
+                    </td>
+                </tr>
+            )}
+            </tbody>
+        </table>
+    };
+
+    renderArpAttributesTablePrintable = (fields) =>
+        <section id="auto-refresh-fields-printable"
+                 className="auto-refresh-fields-printable">
+            {
+                Object.keys(fields).join("\n")
+            }
+        </section>;
+
+    render() {
+        const {metadataAutoRefresh, defaultAutoRefresh, autoRefreshConfiguration, guest} = this.props;
+        const {copiedToClipboardClassName} = this.state;
+
+        const autoRefresh = isEmpty(metadataAutoRefresh) ? defaultAutoRefresh : metadataAutoRefresh;
+        return (
+            <div className="metadata-auto-refresh">
+                <section className="options">
+                    <CheckBox name="auto-refresh-enabled" value={autoRefresh.enabled}
+                              onChange={this.autoRefreshEnabled} readOnly={guest}
+                              info={I18n.t("auto_refresh.enabled")}/>
+                    <CheckBox name="auto-refresh-allow-all" value={autoRefresh.allowAll}
+                              onChange={this.autoRefreshAllowAll} readOnly={guest}
+                              info={I18n.t("auto_refresh.allow_all")}/>
+                    <span className={`button green ${copiedToClipboardClassName}`} onClick={this.copyToClipboard}>
+                        {I18n.t("clipboard.copy")}<i className="fa fa-clone"></i>
+                    </span>
+                </section>
+                <section className="fields">
+                    <h2>{I18n.t("auto_refresh.fields")}</h2>
+                    {this.renderRefreshFieldsTable(autoRefresh, autoRefreshConfiguration, guest)}
+                    {this.renderArpAttributesTablePrintable(autoRefresh.fields)}
+                </section>
+            </div>
+        );
+    }
+}
+
+AutoRefresh.propTypes = {
+    autoRefreshConfiguration: PropTypes.object.isRequired,
+    onChange: PropTypes.func.isRequired,
+    guest: PropTypes.bool.isRequired
+};
+
+AutoRefresh.defaultProps = {
+    defaultAutoRefresh: {enabled: false, allowAll: false, fields: {}}
+};

--- a/manage-gui/src/components/metadata/AutoRefresh.scss
+++ b/manage-gui/src/components/metadata/AutoRefresh.scss
@@ -1,0 +1,143 @@
+@import "../../stylesheets/vars.scss";
+@import "../../stylesheets/mixins.scss";
+
+.metadata-auto-refresh {
+  background-color: white;
+  padding: 20px;
+
+  section.options {
+    display: flex;
+    margin-bottom: 25px;
+
+    .checkbox {
+      margin-right: 10px;
+    }
+
+    span.button {
+      margin-left: auto;
+
+      i.fa-clone {
+        margin-left: 25px;
+      }
+
+      &.copied {
+        animation: pulse 1s;
+        animation-iteration-count: 1;
+        position: relative;
+      }
+
+      @keyframes pulse {
+        0% {
+          box-shadow: 0 0 0 0 white;
+        }
+        70% {
+          box-shadow: 0 0 10px 8px lighten($green, 15%);
+        }
+        100% {
+          box-shadow: 0 0 0 0 white;
+        }
+      }
+    }
+  }
+
+  .fields {
+    h2 {
+      margin-bottom: 20px;
+    }
+  }
+
+  section.auto-refresh-fields-printable {
+    display: none;
+  }
+
+  table.auto-refresh-fields {
+    border: 1px solid white;
+    width: 100%;
+    height: 100%;
+
+    .field {
+      padding: 20px 5px 20px 5px;
+    }
+
+    .value {
+      padding: 15px 5px 15px 5px;
+    }
+
+    thead th {
+      border: 2px solid white;
+      text-align: left;
+      padding: 5px;
+      font-size: larger;
+
+      &.name {
+        width: 15%;
+      }
+
+      &.enabled {
+        width: 40%;
+      }
+    }
+
+    tbody:nth-child(odd) {
+      background-color: $lightest-grey;
+    }
+
+    td {
+      border: 3px solid white;
+      vertical-align: top;
+      height: 100%;
+
+      &.name {
+        i.fa {
+          margin-left: 15px;
+          color: $blue;
+        }
+      }
+
+      ul {
+        height: 100%;
+        list-style: none;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+
+        &.values li {
+          &:first-child {
+            margin-top: 14px;
+          }
+
+          &:last-child {
+            margin-bottom: 14px;
+          }
+        }
+
+        &.matching_rules li {
+          &:first-child {
+            margin-top: 15px;
+          }
+
+          &:last-child {
+            margin-bottom: 15px;
+          }
+        }
+
+        &.sources li {
+          margin-right: 15px;
+
+          &:first-child {
+            margin-top: 10px;
+          }
+
+          &:last-child {
+            margin-bottom: 10px;
+          }
+
+          &:not(:first-child) {
+            margin-top: 5px;
+          }
+        }
+      }
+    }
+
+  }
+}

--- a/manage-gui/src/locale/en.js
+++ b/manage-gui/src/locale/en.js
@@ -66,7 +66,8 @@ I18n.translations.en = {
             requests: "Requests ({{nbr}})",
             import: "Import",
             export: "Export",
-            connected_applications: "Applications ({{nbr}})"
+            connected_applications: "Applications ({{nbr}})",
+            auto_refresh: "Auto refresh"
         },
         notFound: "No Metadata found",
         entityId: "Entity ID",
@@ -548,6 +549,16 @@ I18n.translations.en = {
     server_error: {
         title: "500 Unexpected error",
         description_html: "This is embarrassing; an unexpected error has occurred. It has been logged and reported. Please try again. Still doesn't work? Please click 'Help'.",
+    },
+
+    auto_refresh: {
+        enabled: "Enable auto refresh for this entity",
+        allow_all: "Refresh all fields",
+        fields: "Auto refresh metadata fields",
+        headers: {
+            name: "Name",
+            enabled: "Enable refresh"
+        }
     }
 };
 

--- a/manage-gui/src/pages/System.jsx
+++ b/manage-gui/src/pages/System.jsx
@@ -28,9 +28,10 @@ export default class System extends React.PureComponent {
 
     constructor(props) {
         super(props);
+        const systemFeatures = ["push", "validation", "push_preview", "orphans", "find_my_data"];
         const tabs = props.currentUser.featureToggles
             .map(feature => feature.toLowerCase())
-            .filter(feature => feature !== "edugain");
+            .filter(feature => systemFeatures.includes(feature));
         tabs.push("stats");
         this.state = {
             tabs: tabs,

--- a/manage-server/src/main/java/manage/conf/Features.java
+++ b/manage-server/src/main/java/manage/conf/Features.java
@@ -4,5 +4,5 @@ import java.io.Serializable;
 
 public enum Features implements Serializable {
 
-    VALIDATION, PUSH_PREVIEW, PUSH, ORPHANS, FIND_MY_DATA, EDUGAIN
+    VALIDATION, PUSH_PREVIEW, PUSH, ORPHANS, FIND_MY_DATA, EDUGAIN, AUTO_REFRESH
 }

--- a/manage-server/src/main/java/manage/control/ReaperController.java
+++ b/manage-server/src/main/java/manage/control/ReaperController.java
@@ -1,0 +1,41 @@
+package manage.control;
+
+import manage.service.jobs.MetadataAutoRefreshRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping("/client/startreaper")
+@PreAuthorize("hasRole('ADMIN')")
+public class ReaperController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReaperController.class);
+
+    private final MetadataAutoRefreshRunner metadataAutoRefreshRunner;
+
+    private final ThreadPoolTaskExecutor threadPoolTaskExecutor;
+
+    public ReaperController(MetadataAutoRefreshRunner metadataAutoRefreshRunner,
+                            ThreadPoolTaskExecutor threadPoolTaskExecutor) {
+
+        this.metadataAutoRefreshRunner = metadataAutoRefreshRunner;
+        this.threadPoolTaskExecutor = threadPoolTaskExecutor;
+    }
+
+    @GetMapping("metadataRefresh")
+    public ResponseEntity<Boolean> startMetadataRefresh() {
+        LOG.info("Started metadata refresh reaper manually");
+        threadPoolTaskExecutor.execute(metadataAutoRefreshRunner);
+        return ResponseEntity.status(HttpStatus.OK).body(true);
+    }
+
+}

--- a/manage-server/src/main/java/manage/model/MetaData.java
+++ b/manage-server/src/main/java/manage/model/MetaData.java
@@ -1,5 +1,6 @@
 package manage.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -208,4 +209,34 @@ public class MetaData implements Serializable {
     public void trimSpaces() {
         data.replaceAll((key, value) -> doTrimSpaces(value));
     }
+
+    @Transient
+    @JsonIgnore
+    public boolean isExcludedFromPush() {
+        Object excludedFromPush = this.metaDataFields().get("coin:exclude_from_push");
+        return null != excludedFromPush && (boolean) excludedFromPush;
+    }
+
+    @Transient
+    @JsonIgnore
+    public boolean isMetadataRefreshEnabled() {
+        Map<String, Object> autoRefresh = getAutoRefresh();
+        return (null != autoRefresh && autoRefresh.containsKey("enabled") &&
+                Boolean.parseBoolean(autoRefresh.get("enabled").toString()));
+    }
+
+    @Transient
+    @JsonIgnore
+    public boolean isMetadataRefreshAllowAllEnabled() {
+        Map<String, Object> autoRefresh = getAutoRefresh();
+        return (null != autoRefresh && autoRefresh.containsKey("allowAll") &&
+                Boolean.parseBoolean(autoRefresh.get("allowAll").toString()));
+    }
+
+    @Transient
+    @JsonIgnore
+    public Map<String, Object> getAutoRefresh() {
+        return (Map<String, Object>) data.get("autoRefresh");
+    }
+
 }

--- a/manage-server/src/main/java/manage/model/Revision.java
+++ b/manage-server/src/main/java/manage/model/Revision.java
@@ -9,6 +9,8 @@ import java.time.Instant;
 @NoArgsConstructor
 public class Revision {
 
+    public static final String REVISION_KEY = "revisionnote";
+
     private int number;
     private Instant created;
     private String parentId;

--- a/manage-server/src/main/java/manage/repository/MetaDataRepository.java
+++ b/manage-server/src/main/java/manage/repository/MetaDataRepository.java
@@ -49,6 +49,10 @@ public class MetaDataRepository {
         return mongoTemplate.findById(id, MetaData.class, type);
     }
 
+    public List<MetaData> findAllByType(String type) {
+        return mongoTemplate.findAll(MetaData.class, type);
+    }
+
     public MetaData save(MetaData metaData) {
         metaData.trimSpaces();
         mongoTemplate.insert(metaData, metaData.getType());

--- a/manage-server/src/main/java/manage/service/FeatureService.java
+++ b/manage-server/src/main/java/manage/service/FeatureService.java
@@ -1,0 +1,38 @@
+package manage.service;
+
+import manage.conf.Features;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+@Service
+public class FeatureService {
+
+    private final List<Features> enabledFeatures;
+
+    public FeatureService(@Value("${features}") String features) {
+        List<String> allFeatures = Arrays.stream(Features.values())
+                .map(Enum::name)
+                .collect(toList());
+
+        if (null != features && !features.isEmpty()) {
+            this.enabledFeatures = Stream.of(features.split(","))
+                    .filter(feature -> allFeatures.contains(feature.trim().toUpperCase()))
+                    .map(feature -> Features.valueOf(feature.trim().toUpperCase()))
+                    .collect(toList());
+        } else {
+            this.enabledFeatures = Collections.emptyList();
+        }
+    }
+
+    public boolean isFeatureEnabled(Features feature) {
+        return enabledFeatures.contains(feature);
+    }
+
+}

--- a/manage-server/src/main/java/manage/service/MetaDataService.java
+++ b/manage-server/src/main/java/manage/service/MetaDataService.java
@@ -551,6 +551,10 @@ public class MetaDataService {
         return metaData;
     }
 
+    public List<MetaData> findAllByType(String type) {
+        return metaDataRepository.findAllByType(type);
+    }
+
     private void checkNull(String type, String id, MetaData metaData) {
         if (metaData == null) {
             throw new ResourceNotFoundException(String.format("MetaData type %s with id %s does not exist", type, id));

--- a/manage-server/src/main/java/manage/service/jobs/MetadataAutoRefreshRunner.java
+++ b/manage-server/src/main/java/manage/service/jobs/MetadataAutoRefreshRunner.java
@@ -1,0 +1,213 @@
+package manage.service.jobs;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import manage.conf.Features;
+import manage.conf.MetaDataAutoConfiguration;
+import manage.model.*;
+import manage.service.FeatureService;
+import manage.service.ImporterService;
+import manage.service.MetaDataService;
+import org.everit.json.schema.ValidationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
+@Component
+public class MetadataAutoRefreshRunner implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MetadataAutoRefreshRunner.class);
+
+    private static final String LOG_ALREADY_RUNNING = "Metadata auto refresh is already running";
+
+    private static final String LOG_UPDATE_START = "Start metadata auto refresh";
+
+    private static final String LOG_UPDATE_FINISHED = "Metadata auto refresh finished";
+
+    public static final String METADATA_ENTITYID_KEY = "entityid";
+
+    public static final String METADATA_URL_KEY = "metadataurl";
+
+    public static final String METADATA_FIELDS_KEY = "metaDataFields";
+
+    public static final String AUTO_REFRESH_KEY = "autoRefresh";
+
+    private static final String IMPORT_ERROR_KEY = "errors";
+
+    public static final String PROPERTIES_KEY = "properties";
+
+    public static final String FIELDS_KEY = "fields";
+
+    private static final String REFRESH_UPDATE_USER = "Metadata reaper";
+
+    public static final String AUTO_REFRESH_REVISION_NOTE = "Metadata updated by auto refresh";
+
+    private static final Lock execLock = new ReentrantLock();
+
+    private static boolean running = false;
+
+    private final MetaDataService metaDataService;
+
+    private final ImporterService importerService;
+
+    private final MetaDataAutoConfiguration metaDataAutoConfiguration;
+
+    private final FeatureService featureService;
+
+    public MetadataAutoRefreshRunner(MetaDataService metaDataService,
+                                     ImporterService importerService,
+                                     MetaDataAutoConfiguration metaDataAutoConfiguration,
+                                     FeatureService featureService) {
+
+        this.metaDataService = metaDataService;
+        this.importerService = importerService;
+        this.metaDataAutoConfiguration = metaDataAutoConfiguration;
+        this.featureService = featureService;
+    }
+
+    @Override
+    @Scheduled(cron = "${metadata_import.auto_refresh.cronSchedule}")
+    public void run() {
+        if (featureService.isFeatureEnabled(Features.AUTO_REFRESH)) {
+            // Check whether a Thread is already running
+            if (running || !execLock.tryLock()) {
+                LOG.warn(LOG_ALREADY_RUNNING);
+                return;
+            }
+
+            // Set the lock and execute the reaper
+            running = true;
+            // General exception to ensure that we do not create a deadlock for the scheduled runner
+            try {
+                execute();
+            } catch (Error | Exception e) {
+                LOG.error("Error during thread: {}, stacktrace: {}", e.getMessage(), e.getStackTrace());
+            }
+
+            // Release the lock
+            running = false;
+            execLock.unlock();
+        }
+    }
+
+    private void execute() {
+        LOG.info(LOG_UPDATE_START);
+
+        // Service Provider updates
+        LOG.info("Updating Service Providers");
+        metaDataService.findAllByType(EntityType.SP.getType()).forEach(this::doUpdate);
+
+        // Identity Provider updates
+        LOG.info("Updating Identity Providers");
+        metaDataService.findAllByType(EntityType.IDP.getType()).forEach(this::doUpdate);
+
+        LOG.info(LOG_UPDATE_FINISHED);
+    }
+
+    private void doUpdate(MetaData metaData) {
+        String entityId = metaData.getData().get(METADATA_ENTITYID_KEY).toString();
+
+        if (!metaData.isMetadataRefreshEnabled()) {
+            LOG.info("Auto refresh is disabled - skipping for {}: {}", metaData.getType(), entityId);
+            return;
+        }
+
+        if (!metaData.getData().containsKey(METADATA_URL_KEY) || null == metaData.getData().get(METADATA_URL_KEY)) {
+            LOG.info("No metadata URL found - skipping for {}: {}", metaData.getType(), entityId);
+            return;
+        }
+
+        LOG.info("Running auto refresh for {}: {}", metaData.getType(), entityId);
+        // Retrieve updated fields and removed fields, then update metadata
+        List<String> allowedFields = getAllowedFields(metaData, entityId);
+        if (null == allowedFields) {
+            // Exit here as the previous method will log in case of unexpected behavior
+            return;
+        }
+
+        // Get the new metadata using the metadata URL
+        String metadataUrl = metaData.getData().get(METADATA_URL_KEY).toString();
+        Map<String, Object> importXMLUrlMetaData = importerService.importXMLUrl(EntityType.fromType(metaData.getType()),
+                new Import(metadataUrl, null));
+        if (importXMLUrlMetaData.containsKey(IMPORT_ERROR_KEY)) {
+            LOG.info("Failed to parse metadata from url for {} {} and url {} with error: {}",
+                    metaData.getType(), entityId, metadataUrl, importXMLUrlMetaData.get(IMPORT_ERROR_KEY));
+            return;
+        }
+
+        Map<String, Object> fieldsToUpdate = getUpdatedFields(importXMLUrlMetaData, allowedFields);
+        List<String> fieldsToRemove = getRemovedFields(importXMLUrlMetaData, allowedFields);
+        if ((null == fieldsToUpdate || fieldsToUpdate.isEmpty()) && (null == fieldsToRemove || fieldsToRemove.isEmpty())) {
+            LOG.info("No fields in the retrieved metadata that contain enabled auto refresh fields - skipping");
+            return;
+        }
+
+        metaData.getData().put(Revision.REVISION_KEY, AUTO_REFRESH_REVISION_NOTE);
+        if (null != fieldsToUpdate && !fieldsToUpdate.isEmpty()) {
+            fieldsToUpdate.forEach((key, value) -> metaData.metaDataFields().put(key, value));
+        }
+        if (null != fieldsToRemove && !fieldsToRemove.isEmpty()) {
+            fieldsToRemove.forEach(key -> metaData.metaDataFields().remove(key));
+        }
+
+        try {
+            metaDataService.doPut(metaData, REFRESH_UPDATE_USER, metaData.isExcludedFromPush());
+        } catch (JsonProcessingException exception) {
+            LOG.info("Failed to save changes for {} {}: {}", metaData.getType(), entityId, exception.getMessage());
+        } catch (ValidationException exception) {
+            if (exception.getMessage().contains("No data is changed")) {
+                LOG.info("No changes for {}: {}", metaData.getType(), entityId);
+            } else {
+                LOG.info("Failed to save changes for {} {}: {}", metaData.getType(), entityId, exception.getMessage());
+            }
+        }
+    }
+
+    private List<String> getAllowedFields(MetaData metaData, String entityId) {
+         // Determine allowed fields to update
+        List<String> allowedFields;
+        if (metaData.isMetadataRefreshAllowAllEnabled()) {
+            Map<String, Object> map = metaDataAutoConfiguration.schemaRepresentation(EntityType.fromType(metaData.getType()));
+            Map<String, Object> allFields = (Map<String, Object>) ((Map) ((Map) ((Map) ((Map) map.getOrDefault(PROPERTIES_KEY, new HashMap<>()))
+                    .getOrDefault(AUTO_REFRESH_KEY, new HashMap<>()))
+                    .getOrDefault(PROPERTIES_KEY, new HashMap<>()))
+                    .getOrDefault(FIELDS_KEY, new HashMap<>()))
+                    .getOrDefault(PROPERTIES_KEY, new HashMap<>());
+            allowedFields = new ArrayList<>(allFields.keySet());
+        } else {
+            Map<String, Boolean> configuredFields = null != metaData.getAutoRefresh() ?
+                    (Map<String, Boolean>) metaData.getAutoRefresh().get(FIELDS_KEY) : null;
+            if (null == configuredFields || configuredFields.isEmpty()) {
+                LOG.info("No fields configured for auto refresh and allow all is disabled - skipping for {}: {}",
+                        metaData.getType(), entityId);
+                return null;
+            }
+
+            allowedFields = configuredFields.entrySet().stream()
+                    .filter(Map.Entry::getValue)
+                    .map(Map.Entry::getKey).collect(Collectors.toList());
+        }
+
+        return allowedFields;
+    }
+
+    private Map<String, Object> getUpdatedFields(Map<String, Object> newMetaData, List<String> allowedFields) {
+        Map<String, Object> metadataFields = (Map<String, Object>) newMetaData.get(METADATA_FIELDS_KEY);
+        return metadataFields.entrySet().stream()
+                .filter(entry -> allowedFields.contains(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private List<String> getRemovedFields(Map<String, Object> newMetaData, List<String> allowedFields) {
+        Map<String, Object> metaDataFields = (Map<String, Object>) newMetaData.get(METADATA_FIELDS_KEY);
+        return allowedFields.stream()
+                .filter(fieldKey -> !metaDataFields.containsKey(fieldKey))
+                .collect(Collectors.toList());
+    }
+
+}

--- a/manage-server/src/main/java/manage/web/WebSecurityConfigurer.java
+++ b/manage-server/src/main/java/manage/web/WebSecurityConfigurer.java
@@ -16,6 +16,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -198,6 +199,7 @@ public class WebSecurityConfigurer {
     }
 
     @Configuration
+    @EnableScheduling
     public class MvcConfig implements WebMvcConfigurer {
 
         @Override

--- a/manage-server/src/main/resources/application.yml
+++ b/manage-server/src/main/resources/application.yml
@@ -15,7 +15,7 @@ server:
       cookie:
         secure: true
 
-features: push, validation, push_preview, orphans, find_my_data, edugain, bogus
+features: push, validation, push_preview, orphans, find_my_data, edugain, auto_refresh, bogus
 base_domain: test2.surfconext.nl
 
 push:
@@ -95,6 +95,9 @@ gui:
     background-color: red
     content: LOCAL
 
+metadata_import:
+  auto_refresh:
+    cronSchedule: "-"
 
 # used by the git plugin
 info:

--- a/manage-server/src/main/resources/metadata_configuration/saml20_idp.schema.json
+++ b/manage-server/src/main/resources/metadata_configuration/saml20_idp.schema.json
@@ -115,6 +115,31 @@
         }
       }
     },
+    "autoRefresh": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "allowAll": {
+          "type": "boolean"
+        },
+        "fields": {
+          "properties": {
+            "certData": {
+              "type": "boolean"
+            },
+            "certData2": {
+              "type": "boolean"
+            },
+            "certData3": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
     "stepupEntities": {
       "type": "array",
       "items": {

--- a/manage-server/src/main/resources/metadata_configuration/saml20_sp.schema.json
+++ b/manage-server/src/main/resources/metadata_configuration/saml20_sp.schema.json
@@ -130,6 +130,31 @@
         }
       }
     },
+    "autoRefresh": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "allowAll": {
+          "type": "boolean"
+        },
+        "fields": {
+          "properties": {
+            "certData": {
+              "type": "boolean"
+            },
+            "certData2": {
+              "type": "boolean"
+            },
+            "certData3": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
     "arp": {
       "type": "object",
       "sources": [

--- a/manage-server/src/main/resources/metadata_templates/saml20_idp.template.json
+++ b/manage-server/src/main/resources/metadata_templates/saml20_idp.template.json
@@ -10,5 +10,11 @@
     "name:en": "",
     "SingleSignOnService:0:Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
     "SingleSignOnService:0:Location": ""
+  },
+  "autoRefresh": {
+    "enabled": false,
+    "allowAll": false,
+    "fields": {
+    }
   }
 }

--- a/manage-server/src/main/resources/metadata_templates/saml20_sp.template.json
+++ b/manage-server/src/main/resources/metadata_templates/saml20_sp.template.json
@@ -13,5 +13,11 @@
     "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
     "coin:signature_method": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
   },
-  "allowedEntities": []
+  "allowedEntities": [],
+  "autoRefresh": {
+    "enabled": false,
+    "allowAll": false,
+    "fields": {
+    }
+  }
 }

--- a/manage-server/src/test/java/manage/service/jobs/MetaDataAutoRefreshRunner.java
+++ b/manage-server/src/test/java/manage/service/jobs/MetaDataAutoRefreshRunner.java
@@ -1,0 +1,542 @@
+package manage.service.jobs;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import manage.conf.Features;
+import manage.conf.MetaDataAutoConfiguration;
+import manage.model.EntityType;
+import manage.model.MetaData;
+import manage.model.Revision;
+import manage.service.FeatureService;
+import manage.service.ImporterService;
+import manage.service.MetaDataService;
+import manage.util.LogUtils;
+import manage.util.MemoryAppender;
+import org.everit.json.schema.ValidationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+class MetadataAutoRefreshRunnerTest {
+
+    @Mock
+    MetaDataService metaDataService;
+
+    @Mock
+    ImporterService importerService;
+
+    @Mock
+    FeatureService featureService;
+
+    @Mock
+    MetaDataAutoConfiguration metaDataAutoConfiguration;
+
+    @InjectMocks
+    MetadataAutoRefreshRunner autoRefreshRunner;
+
+    @Captor
+    ArgumentCaptor<MetaData> metaDataCaptor;
+
+    MemoryAppender memoryAppender;
+
+    @BeforeEach
+    void setUp() {
+        // Configure auto refresh fields for mocking the configuration in .schema.json files
+        Map<String, Object> schemaProperties = new HashMap<>();
+        Map<String, Object> autoRefresh = new HashMap<>();
+        schemaProperties.put(MetadataAutoRefreshRunner.PROPERTIES_KEY, autoRefresh);
+        Map<String, Object> autoRefreshConfig = new HashMap<>();
+        autoRefresh.put(MetadataAutoRefreshRunner.AUTO_REFRESH_KEY, autoRefreshConfig);
+        Map<String, Object> autoRefreshProperties = new HashMap<>();
+        autoRefreshConfig.put(MetadataAutoRefreshRunner.PROPERTIES_KEY, autoRefreshProperties);
+        Map<String, Object> fields = new HashMap<>();
+        autoRefreshProperties.put(MetadataAutoRefreshRunner.FIELDS_KEY, fields);
+        Map<String, Object> configurableFields = new HashMap<>();
+        fields.put(MetadataAutoRefreshRunner.PROPERTIES_KEY, configurableFields);
+        configurableFields.put("field1", null);
+        configurableFields.put("field2", null);
+        configurableFields.put("field3", null);
+
+        // Configure mock data returned from importerService.importXMLUrl()
+        Map<String, Object> retrievedMetadata = new HashMap<>();
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("field1", "value");
+        metadata.put("field2", "value");
+        metadata.put("field3", "value");
+        metadata.put("field4", "value");
+        retrievedMetadata.put(MetadataAutoRefreshRunner.METADATA_FIELDS_KEY, metadata);
+
+        when(featureService.isFeatureEnabled(Features.AUTO_REFRESH)).thenReturn(true);
+        lenient().when(metaDataAutoConfiguration.schemaRepresentation(EntityType.SP)).thenReturn(schemaProperties);
+        lenient().when(metaDataAutoConfiguration.schemaRepresentation(EntityType.IDP)).thenReturn(schemaProperties);
+        lenient().when(importerService.importXMLUrl(eq(EntityType.SP), any())).thenReturn(retrievedMetadata);
+        lenient().when(importerService.importXMLUrl(eq(EntityType.IDP), any())).thenReturn(retrievedMetadata);
+
+        Logger logger = (Logger) LoggerFactory.getLogger(MetadataAutoRefreshRunner.class);
+        memoryAppender = LogUtils.configureLogger(logger);
+        memoryAppender.start();
+    }
+
+    @Test
+    void autoRefreshNotEnabled() {
+        when(featureService.isFeatureEnabled(Features.AUTO_REFRESH)).thenReturn(false);
+
+        autoRefreshRunner.run();
+
+        verifyNoInteractions(metaDataService);
+        verifyNoInteractions(metaDataAutoConfiguration);
+        verifyNoInteractions(importerService);
+    }
+
+    @Test
+    void updateServiceProviderAllowAll() throws JsonProcessingException {
+        MetaData current = buildMetadata(EntityType.SP, "entityId", "metadataUrl", true, true, new HashMap<>());
+        current.metaDataFields().put("field1", "old");
+
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.singletonList(current));
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.emptyList());
+
+        assertEquals("old", current.metaDataFields().get("field1"));
+
+        autoRefreshRunner.run();
+
+        verify(metaDataAutoConfiguration, times(1)).schemaRepresentation(EntityType.SP);
+        verify(importerService, times(1)).importXMLUrl(eq(EntityType.SP), any());
+        verify(metaDataService, times(1)).doPut(metaDataCaptor.capture(), anyString(), anyBoolean());
+
+        MetaData result = metaDataCaptor.getValue();
+        assertEquals("value", result.metaDataFields().get("field1"));
+        assertEquals("value", result.metaDataFields().get("field2"));
+        assertEquals("value", result.metaDataFields().get("field3"));
+        assertFalse(result.metaDataFields().containsKey("field4"));
+        assertEquals(MetadataAutoRefreshRunner.AUTO_REFRESH_REVISION_NOTE, result.getData().get(Revision.REVISION_KEY));
+    }
+
+    @Test
+    void updateServiceProviderAllowSubset() throws JsonProcessingException {
+        MetaData current = buildMetadata(EntityType.SP, "entityId", "metadataUrl", true,
+                false, Collections.singletonMap("field1", true));
+        current.metaDataFields().put("field1", "old");
+        current.metaDataFields().put("field2", "old");
+
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.singletonList(current));
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.emptyList());
+
+        assertEquals("old", current.metaDataFields().get("field1"));
+        assertEquals("old", current.metaDataFields().get("field2"));
+
+        autoRefreshRunner.run();
+
+        verify(metaDataAutoConfiguration, times(0)).schemaRepresentation(EntityType.SP);
+        verify(importerService, times(1)).importXMLUrl(eq(EntityType.SP), any());
+        verify(metaDataService, times(1)).doPut(metaDataCaptor.capture(), anyString(), anyBoolean());
+
+        MetaData result = metaDataCaptor.getValue();
+        assertEquals("value", result.metaDataFields().get("field1"));
+        assertEquals("old", result.metaDataFields().get("field2"));
+        assertFalse(result.metaDataFields().containsKey("field3"));
+        assertFalse(result.metaDataFields().containsKey("field4"));
+        assertEquals(MetadataAutoRefreshRunner.AUTO_REFRESH_REVISION_NOTE, result.getData().get(Revision.REVISION_KEY));
+    }
+
+    @Test
+    void updateServiceProviderNoMatchingSubset() throws JsonProcessingException {
+        MetaData current = buildMetadata(EntityType.SP, "entityId", "metadataUrl", true,
+                false, Collections.singletonMap("field5", false));
+        current.metaDataFields().put("field5", "old");
+        current.metaDataFields().put("field6", "old");
+
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.singletonList(current));
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.emptyList());
+
+        autoRefreshRunner.run();
+
+        verify(metaDataAutoConfiguration, times(0)).schemaRepresentation(EntityType.SP);
+        verify(importerService, times(1)).importXMLUrl(eq(EntityType.SP), any());
+        verify(metaDataService, times(0)).doPut(any(), anyString(), anyBoolean());
+    }
+
+    @Test
+    void updateServiceProviderRemoveFieldIfRemovedFromMetadata() throws JsonProcessingException {
+        MetaData current = buildMetadata(EntityType.SP, "entityId", "metadataUrl", true,
+                false, Collections.singletonMap("field5", true));
+        current.metaDataFields().put("field5", "old");
+        current.metaDataFields().put("field6", "old");
+
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.singletonList(current));
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.emptyList());
+
+        autoRefreshRunner.run();
+
+        verify(metaDataAutoConfiguration, times(0)).schemaRepresentation(EntityType.SP);
+        verify(importerService, times(1)).importXMLUrl(eq(EntityType.SP), any());
+        verify(metaDataService, times(1)).doPut(metaDataCaptor.capture(), anyString(), anyBoolean());
+
+        MetaData result = metaDataCaptor.getValue();
+        assertFalse(result.metaDataFields().containsKey("field5"));
+        assertEquals(MetadataAutoRefreshRunner.AUTO_REFRESH_REVISION_NOTE, result.getData().get(Revision.REVISION_KEY));
+    }
+
+    @Test
+    void updateServiceProviderDoNotAllowSubsetWithoutFields() throws JsonProcessingException {
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.singletonList(
+                buildMetadata(EntityType.SP, "entityId", "metadataUrl", true, false, new HashMap<>())
+        ));
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.emptyList());
+
+        autoRefreshRunner.run();
+
+        verify(metaDataService, times(0)).doPut(any(), anyString(), anyBoolean());
+        verifyNoInteractions(metaDataAutoConfiguration);
+        verifyNoInteractions(importerService);
+    }
+
+    @Test
+    void updateServiceProviderNoChanges() throws JsonProcessingException {
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.singletonList(
+                buildMetadata(EntityType.SP, "entityId", "metadataUrl", true, true, new HashMap<>())
+        ));
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.emptyList());
+        when(metaDataService.doPut(any(), anyString(), anyBoolean()))
+                .thenThrow(new ValidationException(null, "No data is changed", ""));
+
+        autoRefreshRunner.run();
+
+        verify(metaDataService, times(1)).doPut(any(), anyString(), anyBoolean());
+        verify(metaDataAutoConfiguration, times(1)).schemaRepresentation(EntityType.SP);
+        verify(importerService, times(1)).importXMLUrl(eq(EntityType.SP), any());
+    }
+
+    @Test
+    void updateServiceProviderInvalidMetadata() throws JsonProcessingException {
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.singletonList(
+                buildMetadata(EntityType.SP, "entityId", "metadataUrl", true, true, new HashMap<>())
+        ));
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.emptyList());
+        when(importerService.importXMLUrl(eq(EntityType.SP), any())).thenReturn(Collections.singletonMap("errors", "invalid metadata"));
+
+        autoRefreshRunner.run();
+
+        verify(metaDataService, times(0)).doPut(any(), anyString(), anyBoolean());
+        verify(metaDataAutoConfiguration, times(1)).schemaRepresentation(EntityType.SP);
+        verify(importerService, times(1)).importXMLUrl(eq(EntityType.SP), any());
+    }
+
+    @Test
+    void updateServiceProviderValidationError() throws JsonProcessingException {
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.singletonList(
+                buildMetadata(EntityType.SP, "entityId", "metadataUrl", true, true, new HashMap<>())
+        ));
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.emptyList());
+        when(metaDataService.doPut(any(), anyString(), anyBoolean()))
+                .thenThrow(new ValidationException(null, "some error occurred", ""));
+
+        autoRefreshRunner.run();
+
+        verify(metaDataService, times(1)).doPut(any(), anyString(), anyBoolean());
+        verify(metaDataAutoConfiguration, times(1)).schemaRepresentation(EntityType.SP);
+        verify(importerService, times(1)).importXMLUrl(eq(EntityType.SP), any());
+        assertTrue(memoryAppender.contains("Failed to save changes for saml20_sp entityId: #: some error occurred", Level.INFO));
+    }
+
+    @Test
+    void updateServiceProviderJsonProcessingError() throws JsonProcessingException {
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.singletonList(
+                buildMetadata(EntityType.SP, "entityId", "metadataUrl", true, true, new HashMap<>())
+        ));
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.emptyList());
+        when(metaDataService.doPut(any(), anyString(), anyBoolean()))
+                .thenThrow(new MockJsonProcessingException("some error occurred"));
+
+        autoRefreshRunner.run();
+
+        verify(metaDataService, times(1)).doPut(any(), anyString(), anyBoolean());
+        verify(metaDataAutoConfiguration, times(1)).schemaRepresentation(EntityType.SP);
+        verify(importerService, times(1)).importXMLUrl(eq(EntityType.SP), any());
+        assertTrue(memoryAppender.contains("Failed to save changes for saml20_sp entityId: some error occurred", Level.INFO));
+    }
+
+    @Test
+    void updateServiceProviderNoAutoRefreshSettings() throws JsonProcessingException {
+        MetaData metaData = buildMetadata(EntityType.SP, "entityId", "metadataUrl", false, false, new HashMap<>());
+        metaData.getData().put(MetadataAutoRefreshRunner.AUTO_REFRESH_KEY, null);
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.singletonList(metaData));
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.emptyList());
+
+        autoRefreshRunner.run();
+
+        verify(metaDataService, times(0)).doPut(any(), anyString(), anyBoolean());
+        verifyNoInteractions(metaDataAutoConfiguration);
+        verifyNoInteractions(importerService);
+    }
+
+    @Test
+    void updateServiceProviderAutoRefreshDisabled() throws JsonProcessingException {
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.singletonList(
+                buildMetadata(EntityType.SP, "entityId", "metadataUrl", false, false, new HashMap<>())
+        ));
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.emptyList());
+
+        autoRefreshRunner.run();
+
+        verify(metaDataService, times(0)).doPut(any(), anyString(), anyBoolean());
+        verifyNoInteractions(metaDataAutoConfiguration);
+        verifyNoInteractions(importerService);
+    }
+
+    @Test
+    void updateServiceProviderNoMetadataUrl() throws JsonProcessingException {
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.singletonList(
+                buildMetadata(EntityType.SP, "entityId", null, true, false, new HashMap<>())
+        ));
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.emptyList());
+
+        autoRefreshRunner.run();
+
+        verify(metaDataService, times(0)).doPut(any(), anyString(), anyBoolean());
+        verifyNoInteractions(metaDataAutoConfiguration);
+        verifyNoInteractions(importerService);
+    }
+
+    @Test
+    void updateIdentityProviderAllowAll() throws JsonProcessingException {
+        MetaData current = buildMetadata(EntityType.IDP, "entityId", "metadataUrl", true, true, new HashMap<>());
+        current.metaDataFields().put("field1", "old");
+
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.emptyList());
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.singletonList(current));
+
+        assertEquals("old", current.metaDataFields().get("field1"));
+
+        autoRefreshRunner.run();
+
+        verify(metaDataAutoConfiguration, times(1)).schemaRepresentation(EntityType.IDP);
+        verify(importerService, times(1)).importXMLUrl(eq(EntityType.IDP), any());
+        verify(metaDataService, times(1)).doPut(metaDataCaptor.capture(), anyString(), anyBoolean());
+
+        MetaData result = metaDataCaptor.getValue();
+        assertEquals("value", result.metaDataFields().get("field1"));
+        assertEquals("value", result.metaDataFields().get("field2"));
+        assertEquals("value", result.metaDataFields().get("field3"));
+        assertFalse(result.metaDataFields().containsKey("field4"));
+        assertEquals(MetadataAutoRefreshRunner.AUTO_REFRESH_REVISION_NOTE, result.getData().get(Revision.REVISION_KEY));
+    }
+
+    @Test
+    void updateIdentityProviderAllowSubset() throws JsonProcessingException {
+        MetaData current = buildMetadata(EntityType.IDP, "entityId", "metadataUrl", true,
+                false, Collections.singletonMap("field1", true));
+        current.metaDataFields().put("field1", "old");
+        current.metaDataFields().put("field2", "old");
+
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.emptyList());
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.singletonList(current));
+
+        assertEquals("old", current.metaDataFields().get("field1"));
+        assertEquals("old", current.metaDataFields().get("field2"));
+
+        autoRefreshRunner.run();
+
+        verify(metaDataAutoConfiguration, times(0)).schemaRepresentation(EntityType.IDP);
+        verify(importerService, times(1)).importXMLUrl(eq(EntityType.IDP), any());
+        verify(metaDataService, times(1)).doPut(metaDataCaptor.capture(), anyString(), anyBoolean());
+
+        MetaData result = metaDataCaptor.getValue();
+        assertEquals("value", result.metaDataFields().get("field1"));
+        assertEquals("old", result.metaDataFields().get("field2"));
+        assertFalse(result.metaDataFields().containsKey("field3"));
+        assertFalse(result.metaDataFields().containsKey("field4"));
+        assertEquals(MetadataAutoRefreshRunner.AUTO_REFRESH_REVISION_NOTE, result.getData().get(Revision.REVISION_KEY));
+    }
+
+    @Test
+    void updateIdentityProviderNoMatchingSubset() throws JsonProcessingException {
+        MetaData current = buildMetadata(EntityType.IDP, "entityId", "metadataUrl", true,
+                false, Collections.singletonMap("field5", false));
+        current.metaDataFields().put("field5", "old");
+        current.metaDataFields().put("field6", "old");
+
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.emptyList());
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.singletonList(current));
+
+        autoRefreshRunner.run();
+
+        verify(metaDataAutoConfiguration, times(0)).schemaRepresentation(EntityType.IDP);
+        verify(importerService, times(1)).importXMLUrl(eq(EntityType.IDP), any());
+        verify(metaDataService, times(0)).doPut(any(), anyString(), anyBoolean());
+    }
+
+    @Test
+    void updateIdentityProviderRemoveFieldIfRemovedFromMetadata() throws JsonProcessingException {
+        MetaData current = buildMetadata(EntityType.IDP, "entityId", "metadataUrl", true,
+                false, Collections.singletonMap("field5", true));
+        current.metaDataFields().put("field5", "old");
+        current.metaDataFields().put("field6", "old");
+
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.emptyList());
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.singletonList(current));
+
+        autoRefreshRunner.run();
+
+        verify(metaDataAutoConfiguration, times(0)).schemaRepresentation(EntityType.IDP);
+        verify(importerService, times(1)).importXMLUrl(eq(EntityType.IDP), any());
+        verify(metaDataService, times(1)).doPut(metaDataCaptor.capture(), anyString(), anyBoolean());
+
+        MetaData result = metaDataCaptor.getValue();
+        assertFalse(result.metaDataFields().containsKey("field5"));
+        assertEquals(MetadataAutoRefreshRunner.AUTO_REFRESH_REVISION_NOTE, result.getData().get(Revision.REVISION_KEY));
+    }
+
+    @Test
+    void updateIdentityProviderDoNotAllowSubsetWithoutFields() throws JsonProcessingException {
+        MetaData current = buildMetadata(EntityType.IDP, "entityId", "metadataUrl", true, false, new HashMap<>());
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.singletonList(current));
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.emptyList());
+
+        autoRefreshRunner.run();
+
+        verify(metaDataService, times(0)).doPut(any(), anyString(), anyBoolean());
+        verifyNoInteractions(metaDataAutoConfiguration);
+        verifyNoInteractions(importerService);
+    }
+
+    @Test
+    void updateIdentityProviderNoChanges() throws JsonProcessingException {
+        MetaData current = buildMetadata(EntityType.IDP, "entityId", "metadataUrl", true, true, new HashMap<>());
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.singletonList(current));
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.emptyList());
+        when(metaDataService.doPut(any(), anyString(), anyBoolean()))
+                .thenThrow(new ValidationException(null, "No data is changed", ""));
+
+        autoRefreshRunner.run();
+
+        verify(metaDataService, times(1)).doPut(any(), anyString(), anyBoolean());
+        verify(metaDataAutoConfiguration, times(1)).schemaRepresentation(EntityType.IDP);
+        verify(importerService, times(1)).importXMLUrl(eq(EntityType.IDP), any());
+    }
+
+    @Test
+    void updateIdentityProviderInvalidMetadata() throws JsonProcessingException {
+        MetaData current = buildMetadata(EntityType.IDP, "entityId", "metadataUrl", true, true, new HashMap<>());
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.singletonList(current));
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.emptyList());
+        when(importerService.importXMLUrl(eq(EntityType.IDP), any())).thenReturn(Collections.singletonMap("errors", "invalid metadata"));
+
+        autoRefreshRunner.run();
+
+        verify(metaDataService, times(0)).doPut(any(), anyString(), anyBoolean());
+        verify(metaDataAutoConfiguration, times(1)).schemaRepresentation(EntityType.IDP);
+        verify(importerService, times(1)).importXMLUrl(eq(EntityType.IDP), any());
+    }
+
+    @Test
+    void updateIdentityProviderValidationError() throws JsonProcessingException {
+        MetaData current = buildMetadata(EntityType.IDP, "entityId", "metadataUrl", true, true, new HashMap<>());
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.singletonList(current));
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.emptyList());
+        when(metaDataService.doPut(any(), anyString(), anyBoolean()))
+                .thenThrow(new ValidationException(null, "some error occurred", ""));
+
+        autoRefreshRunner.run();
+
+        verify(metaDataService, times(1)).doPut(any(), anyString(), anyBoolean());
+        verify(metaDataAutoConfiguration, times(1)).schemaRepresentation(EntityType.IDP);
+        verify(importerService, times(1)).importXMLUrl(eq(EntityType.IDP), any());
+        assertTrue(memoryAppender.contains("Failed to save changes for saml20_idp entityId: #: some error occurred", Level.INFO));
+    }
+
+    @Test
+    void updateIdentityProviderJsonProcessingError() throws JsonProcessingException {
+        MetaData current = buildMetadata(EntityType.IDP, "entityId", "metadataUrl", true, true, new HashMap<>());
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.singletonList(current));
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.emptyList());
+        when(metaDataService.doPut(any(), anyString(), anyBoolean()))
+                .thenThrow(new MockJsonProcessingException("some error occurred"));
+
+        autoRefreshRunner.run();
+
+        verify(metaDataService, times(1)).doPut(any(), anyString(), anyBoolean());
+        verify(metaDataAutoConfiguration, times(1)).schemaRepresentation(EntityType.IDP);
+        verify(importerService, times(1)).importXMLUrl(eq(EntityType.IDP), any());
+        assertTrue(memoryAppender.contains("Failed to save changes for saml20_idp entityId: some error occurred", Level.INFO));
+    }
+
+    @Test
+    void updateIdentityProviderNoAutoRefreshSettings() throws JsonProcessingException {
+        MetaData metaData = buildMetadata(EntityType.IDP, "entityId", "metadataUrl", false, false, new HashMap<>());
+        metaData.getData().put(MetadataAutoRefreshRunner.AUTO_REFRESH_KEY, null);
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.singletonList(metaData));
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.emptyList());
+
+        autoRefreshRunner.run();
+
+        verify(metaDataService, times(0)).doPut(any(), anyString(), anyBoolean());
+        verifyNoInteractions(metaDataAutoConfiguration);
+        verifyNoInteractions(importerService);
+    }
+
+    @Test
+    void updateIdentityProviderAutoRefreshDisabled() throws JsonProcessingException {
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.singletonList(
+                buildMetadata(EntityType.IDP, "entityId", "metadataUrl", false, false, new HashMap<>())
+        ));
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.emptyList());
+
+        autoRefreshRunner.run();
+
+        verify(metaDataService, times(0)).doPut(any(), anyString(), anyBoolean());
+        verifyNoInteractions(metaDataAutoConfiguration);
+        verifyNoInteractions(importerService);
+    }
+
+    @Test
+    void updateIdentityProviderNoMetadataUrl() throws JsonProcessingException {
+        when(metaDataService.findAllByType(EntityType.IDP.getType())).thenReturn(Collections.singletonList(
+                buildMetadata(EntityType.IDP, "entityId", null, true, false, new HashMap<>())
+        ));
+        when(metaDataService.findAllByType(EntityType.SP.getType())).thenReturn(Collections.emptyList());
+
+        autoRefreshRunner.run();
+
+        verify(metaDataService, times(0)).doPut(any(), anyString(), anyBoolean());
+        verifyNoInteractions(metaDataAutoConfiguration);
+        verifyNoInteractions(importerService);
+    }
+
+    private MetaData buildMetadata(EntityType type, String entityId, String metadataUrl, boolean enableAutoRefresh,
+                                   boolean allowAll, Map<String, Object> allowedFields) {
+
+        Map<String, Object> data = new HashMap<>();
+        Map<String, Object> autoRefreshData = new HashMap<>();
+        autoRefreshData.put("enabled", enableAutoRefresh);
+        autoRefreshData.put("allowAll", allowAll);
+        autoRefreshData.put(MetadataAutoRefreshRunner.FIELDS_KEY, allowedFields);
+        data.put(MetadataAutoRefreshRunner.METADATA_ENTITYID_KEY, entityId);
+        data.put(MetadataAutoRefreshRunner.METADATA_URL_KEY, metadataUrl);
+        data.put(MetadataAutoRefreshRunner.AUTO_REFRESH_KEY, autoRefreshData);
+        data.put(MetadataAutoRefreshRunner.METADATA_FIELDS_KEY, new HashMap<>());
+        return new MetaData(type.getType(), data);
+    }
+
+    private static class MockJsonProcessingException extends JsonProcessingException {
+        public MockJsonProcessingException(String message) {
+            super(message);
+        }
+    }
+
+}

--- a/manage-server/src/test/java/manage/util/LogUtils.java
+++ b/manage-server/src/test/java/manage/util/LogUtils.java
@@ -1,0 +1,17 @@
+package manage.util;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import org.slf4j.LoggerFactory;
+
+public class LogUtils {
+
+    public static MemoryAppender configureLogger(Logger logger) {
+        MemoryAppender memoryAppender = new MemoryAppender();
+        memoryAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+        logger.setLevel(Level.INFO);
+        logger.addAppender(memoryAppender);
+        return memoryAppender;
+    }
+}

--- a/manage-server/src/test/java/manage/util/MemoryAppender.java
+++ b/manage-server/src/test/java/manage/util/MemoryAppender.java
@@ -1,0 +1,14 @@
+package manage.util;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+public class MemoryAppender extends ListAppender<ILoggingEvent> {
+
+    public boolean contains(String string, Level level) {
+        return this.list.stream()
+                .anyMatch(event -> event.getFormattedMessage().toLowerCase().contains(string.toLowerCase())
+                        && event.getLevel().equals(level));
+    }
+}

--- a/manage-server/src/test/resources/test.properties
+++ b/manage-server/src/test/resources/test.properties
@@ -48,4 +48,4 @@ spring.mail.host=localhost
 spring.mail.port=3025
 spring.data.mongodb.uri=mongodb://localhost:27017/metadata_test
 spring.main.banner-mode=off
-metadata_import.auto_refresh.cronSchedule: "-"
+metadata_import.auto_refresh.cronSchedule=0 0 0 30 2 *

--- a/manage-server/src/test/resources/test.properties
+++ b/manage-server/src/test/resources/test.properties
@@ -1,6 +1,6 @@
 spring.profiles.active=dev
 base_domain=test2.surfconext.nl
-features=push, validation, push_preview, orphans, find_my_data, edugain, bogus
+features=push, validation, push_preview, orphans, find_my_data, edugain, auto_refresh, bogus
 gui.disclaimer.background-color=red
 gui.disclaimer.content=LOCAL
 info.build.artifact=@project.artifactId@
@@ -48,3 +48,4 @@ spring.mail.host=localhost
 spring.mail.port=3025
 spring.data.mongodb.uri=mongodb://localhost:27017/metadata_test
 spring.main.banner-mode=off
+metadata_import.auto_refresh.cronSchedule: "-"


### PR DESCRIPTION
This PR adds a feature which makes it possible to automatically refresh certain metadata fields for IdPs/SPs based on a metadata import. By default fields that can be updated through this import include "cerdata", "cerdata2" and "cerdata3", although this can be configured by changing the schema.json files. 

A new tab is added for IdPs/SPs that allows for easy configuration of the automatic refresh. For each IdP/SP it is possible to disable automatic refresh entirely, enable it for only a specific set of fields or to enable it for all fields. If automatic refresh is enabled for one or more fields and the IdP/SP has a metadata-url configured, the IdP/SP is included in the automatic metadata refresh with the metadata-url as the import source. If a change in the  an enabled field is detected, that field is either updated or removed entirely.

The refresh can be kicked off in two ways:
1. Via the newly added endpoint: /manage/api/client/startreaper/metadataRefresh
2. Via a cron schedule which is configurable in the application.yml

This feature can be turned off entirely by removing it from the feature list in application.yml.  The cron can be turned of separately by setting the cron schedule to "-". By default new IdPs/SPs do not have automatic refresh enabled, although this can be easily configured by update the template.json files.