### PR TITLE
Automated metadata refresh frontend improvements

### DIFF
--- a/manage-gui/src/components/metadata/AutoRefresh.jsx
+++ b/manage-gui/src/components/metadata/AutoRefresh.jsx
@@ -62,7 +62,7 @@ export default class AutoRefresh extends React.PureComponent {
         return aKey.localeCompare(bKey);
     };
 
-    renderRefreshFieldsTable = (autoRefresh, autoRefreshConfiguration, guest) => {
+    renderRefreshFieldsTable = (autoRefresh, autoRefreshConfiguration, guest, metaDataUrl) => {
         const autoRefreshFields = autoRefreshConfiguration.properties.fields.properties;
         const fieldKeys = Object.keys(autoRefreshFields);
         fieldKeys.sort(this.sortFieldKeys(autoRefreshFields, autoRefresh.fields));
@@ -82,13 +82,20 @@ export default class AutoRefresh extends React.PureComponent {
                     <td className="value">
                         <CheckBox name={fieldKey}
                                   value={autoRefresh.fields[fieldKey] ?? false}
-                                  readOnly={guest || autoRefresh.allowAll || !autoRefresh.enabled}
+                                  readOnly={guest || autoRefresh.allowAll || !autoRefresh.enabled || !metaDataUrl}
                                   onChange={e => this.onChange(fieldKey, e.target.checked)}/>
                     </td>
                 </tr>
             )}
             </tbody>
         </table>
+    };
+
+    renderNoMetaDataUrlWarning = () => {
+        return <section id="auto-refresh-no-metadata-url" className="metadata-url-warning">
+            <h2>{I18n.t(`auto_refresh.no_metadata_url.header`)}</h2>
+            <p>{I18n.t(`auto_refresh.no_metadata_url.body`)}</p>
+        </section>
     };
 
     renderArpAttributesTablePrintable = (fields) =>
@@ -100,18 +107,19 @@ export default class AutoRefresh extends React.PureComponent {
         </section>;
 
     render() {
-        const {metadataAutoRefresh, defaultAutoRefresh, autoRefreshConfiguration, guest} = this.props;
+        const {metadataAutoRefresh, defaultAutoRefresh, autoRefreshConfiguration, guest, metaDataUrl} = this.props;
         const {copiedToClipboardClassName} = this.state;
 
         const autoRefresh = isEmpty(metadataAutoRefresh) ? defaultAutoRefresh : metadataAutoRefresh;
         return (
             <div className="metadata-auto-refresh">
+                {!metaDataUrl && this.renderNoMetaDataUrlWarning()}
                 <section className="options">
                     <CheckBox name="auto-refresh-enabled" value={autoRefresh.enabled}
-                              onChange={this.autoRefreshEnabled} readOnly={guest}
+                              onChange={this.autoRefreshEnabled} readOnly={guest || !metaDataUrl}
                               info={I18n.t("auto_refresh.enabled")}/>
                     <CheckBox name="auto-refresh-allow-all" value={autoRefresh.allowAll}
-                              onChange={this.autoRefreshAllowAll} readOnly={guest}
+                              onChange={this.autoRefreshAllowAll} readOnly={guest || !metaDataUrl}
                               info={I18n.t("auto_refresh.allow_all")}/>
                     <span className={`button green ${copiedToClipboardClassName}`} onClick={this.copyToClipboard}>
                         {I18n.t("clipboard.copy")}<i className="fa fa-clone"></i>
@@ -119,7 +127,7 @@ export default class AutoRefresh extends React.PureComponent {
                 </section>
                 <section className="fields">
                     <h2>{I18n.t("auto_refresh.fields")}</h2>
-                    {this.renderRefreshFieldsTable(autoRefresh, autoRefreshConfiguration, guest)}
+                    {this.renderRefreshFieldsTable(autoRefresh, autoRefreshConfiguration, guest, metaDataUrl)}
                     {this.renderArpAttributesTablePrintable(autoRefresh.fields)}
                 </section>
             </div>

--- a/manage-gui/src/components/metadata/AutoRefresh.scss
+++ b/manage-gui/src/components/metadata/AutoRefresh.scss
@@ -5,6 +5,11 @@
   background-color: white;
   padding: 20px;
 
+  section.metadata-url-warning {
+    margin-bottom: 25px;
+    color: $orange;
+  }
+
   section.options {
     display: flex;
     margin-bottom: 25px;

--- a/manage-gui/src/locale/en.js
+++ b/manage-gui/src/locale/en.js
@@ -555,6 +555,10 @@ I18n.translations.en = {
         enabled: "Enable auto refresh for this entity",
         allow_all: "Refresh all fields",
         fields: "Auto refresh metadata fields",
+        no_metadata_url: {
+            header: "No metadata URL provided",
+            body: "Entities without metadata URL are skipped during auto refresh. You can configure a URL in the 'Connection' tab."
+        },
         headers: {
             name: "Name",
             enabled: "Enable refresh"

--- a/manage-gui/src/pages/Detail.jsx
+++ b/manage-gui/src/pages/Detail.jsx
@@ -253,8 +253,9 @@ class Detail extends React.PureComponent {
                             this.setState({revisions: revisions, requests: requests, changeRequestsLoaded: true});
                         });
                 });
+                const configuration = this.props.configuration.find(conf => conf.title === type);
                 if (currentUser.featureToggles && currentUser.featureToggles.includes(autoRefreshFeature) &&
-                    (type === 'saml20_idp' || type === 'saml20_sp')) {
+                    (type === 'saml20_idp' || type === 'saml20_sp') && configuration.properties.autoRefresh) {
 
                     const autoRefreshTab = "auto_refresh";
                     const metadataTab = "metadata";
@@ -918,6 +919,7 @@ class Detail extends React.PureComponent {
                     <AutoRefresh
                         metadataAutoRefresh={metaData.data.autoRefresh}
                         autoRefreshConfiguration={configuration.properties.autoRefresh}
+                        metaDataUrl={metaData.data.metadataurl}
                         onChange={this.onChange("autoRefresh")}
                         guest={guest}
                     />


### PR DESCRIPTION
In the PR https://github.com/OpenConext/OpenConext-manage/pull/112 a automated metadata refresh feature was created. Part of this PR was a new tab in the frontend for the SP/IdP entities in which this feature could be configured. Some feedback was provided regarding this frontend, solutions to this feedback has been implemented in this PR:

- The option to enable the automated refresh was enabled even if no metadata URL was configured. This did not cause any problems as entities without metadata URL are skipped in the refresh, but it can lead to confusing situations. Now the check-boxes are disabled and a warning is displayed.
- When the new metadata fields were not present in the schema.json file the tab would still be available but trying to open the tab would lead to errors. Now the tab is no longer available when these fields are missing in the schema.json file.

