### PR TITLE
Downgrade metadata auto refresh skip message to 'debug'.

### DIFF
--- a/manage-server/src/main/java/manage/service/jobs/MetadataAutoRefreshRunner.java
+++ b/manage-server/src/main/java/manage/service/jobs/MetadataAutoRefreshRunner.java
@@ -130,7 +130,7 @@ public class MetadataAutoRefreshRunner implements Runnable {
         String entityId = metaData.getData().get(METADATA_ENTITYID_KEY).toString();
 
         if (!metaData.isMetadataRefreshEnabled()) {
-            LOG.info("Auto refresh is disabled - skipping for {}: {}", metaData.getType(), entityId);
+            LOG.debug("Auto refresh is not enabled for entity - skipping for {}: {}", metaData.getType(), entityId);
             return;
         }
 


### PR DESCRIPTION
If you have thousands of entities in your database this generates a lot of needless log entries on production. Kept at debug level for development use.