### PR TITLE
Increase shibmb range from 10 to 30

### DIFF
--- a/manage-server/src/main/java/manage/format/EngineBlockFormatter.java
+++ b/manage-server/src/main/java/manage/format/EngineBlockFormatter.java
@@ -318,7 +318,7 @@ public class EngineBlockFormatter {
         final Map<String, Object> metadata = (Map<String, Object>) result.computeIfAbsent("metadata", key -> new
                 TreeMap<>());
         Map<String, Object> metaDataFields = (Map<String, Object>) source.get("metaDataFields");
-        IntStream.range(0, 10).forEach(i -> {
+        IntStream.range(0, 30).forEach(i -> {
             String allowed = parseValueToString(metaDataFields.get("shibmd:scope:" + i + ":allowed"));
             String regexp = parseValueToString(metaDataFields.get("shibmd:scope:" + i + ":regexp"));
 


### PR DESCRIPTION
Currently only shibmb 0-9 are exported; we need more. Increase the limit from 10 to 30.