### PR TITLE
Allow any URI to be used as LoA

### DIFF
--- a/manage-server/src/main/resources/metadata_configuration/oidc10_rp.schema.json
+++ b/manage-server/src/main/resources/metadata_configuration/oidc10_rp.schema.json
@@ -477,7 +477,7 @@
         },
         "coin:stepup:requireloa": {
           "type": "string",
-          "format": "url",
+          "format": "uri",
           "enum": [
             "http://test.surfconext.nl/assurance/loa1.5",
             "http://test.surfconext.nl/assurance/loa2",

--- a/manage-server/src/main/resources/metadata_configuration/saml20_sp.schema.json
+++ b/manage-server/src/main/resources/metadata_configuration/saml20_sp.schema.json
@@ -606,7 +606,7 @@
         },
         "coin:stepup:requireloa": {
           "type": "string",
-          "format": "url",
+          "format": "uri",
           "enum": [
             "http://test.surfconext.nl/assurance/loa1.5",
             "http://test.surfconext.nl/assurance/loa2",

--- a/manage-server/src/main/resources/metadata_configuration/single_tenant_template.schema.json
+++ b/manage-server/src/main/resources/metadata_configuration/single_tenant_template.schema.json
@@ -485,7 +485,7 @@
         },
         "coin:stepup:requireloa": {
           "type": "string",
-          "format": "url",
+          "format": "uri",
           "enum": [
             "http://test.surfconext.nl/assurance/loa1.5",
             "http://test.surfconext.nl/assurance/loa2",


### PR DESCRIPTION
We use URNs for this field and while upgrading Manage from v6 > v7 we noticed that URNs were no longer allowed.
The level of assurance set in Manage is effectively the AuthnConextClassRef in the SAML-response and per SAML 2.0 specifications this field is defined as xs:anyURI and should allow URNs as well.