### PR TITLE
Introduction of 'Organisation' entity

### DIFF
--- a/manage-gui/src/api/index.js
+++ b/manage-gui/src/api/index.js
@@ -95,12 +95,20 @@ export function save(metaData) {
     return postPutJson("metadata", metaData, "post");
 }
 
+export function getAllEntities() {
+    return fetchJson(`metadata/allentities`);
+}
+
 export function remove(metaData, revisionNote) {
     return postPutJson(`metadata/${metaData.type}/${metaData.id}`, {revisionNote}, "put");
 }
 
 export function update(metaData) {
     return postPutJson("metadata", metaData, "put");
+}
+
+export function validateUniqueField(type, fieldName, value) {
+    return fetchJson(`metadata/validate-unique-field/${type}/${fieldName}/${value}`, {}, {}, false);
 }
 
 export function restoreRevision(id, type, parentType) {

--- a/manage-gui/src/components/Autocomplete.jsx
+++ b/manage-gui/src/components/Autocomplete.jsx
@@ -70,62 +70,96 @@ export default class Autocomplete extends React.PureComponent {
     }
 
     getTable(suggestions, selected, itemSelected, query, type) {
+        const isOrganisation = type === "organisation";
         const isPolicy = type === "policy";
         return <table className="result">
             <thead>
             <tr>
-                <th className="count"></th>
+                {!isOrganisation && <th className="count"></th>}
                 <th className="name">{I18n.t("metadata_autocomplete.name")}</th>
-                {!isPolicy && <th className="organization">{I18n.t("metadata_autocomplete.organization")}</th>}
+                {!isPolicy && !isOrganisation && <th className="organization">{I18n.t("metadata_autocomplete.organization")}</th>}
                 {isPolicy && <th className="organization">{I18n.t("metadata_autocomplete.policy")}</th>}
-                <th className="type">{I18n.t("metadata_autocomplete.type")}</th>
-                <th className="state">{I18n.t("metadata_autocomplete.state")}</th>
-                <th className="entity_id">{I18n.t("metadata_autocomplete.entity_id")}</th>
+                {!isOrganisation && <th className="type">{I18n.t("metadata_autocomplete.type")}</th>}
+                {!isOrganisation && <th className="state">{I18n.t("metadata_autocomplete.state")}</th>}
+                {!isOrganisation && <th className="entity_id">{I18n.t("metadata_autocomplete.entity_id")}</th>}
                 <th className="info">{I18n.t("metadata_autocomplete.notes")}</th>
                 <th className="link">{I18n.t("metadata_autocomplete.link")}</th>
             </tr>
             </thead>
             <tbody>
             {suggestions
-                .map((item, index) =>
-                    (
-                        <tr key={index}
-                            className={selected === index ? "active" : ""}
-                            onClick={() => itemSelected(item)}
-                            ref={ref => {
-                                if (selected === index) {
-                                    this.selectedRow = ref;
-                                }
-                            }}>
-                            <td className="count">{index + 1}</td>
-                            <td>
-                                {!isPolicy && this.item(getNameForLanguage(item.data.metaDataFields), query)}
-                                {isPolicy && this.item(item.data.name, query)}
-                            </td>
-                            <td>
-                                {!isPolicy && this.item(getOrganisationForLanguage(item.data.metaDataFields), query)}
-                                {isPolicy && I18n.t(`topBannerDetails.${item.data.type}`)}
-                            </td>
-                            <td>{item.type}</td>
-                            <td className="state">
-                                <CheckBox name="state" value={item.data.state === "prodaccepted" || isPolicy}
-                                          onChange={() => this} readOnly={true}/>
-                            </td>
-                            <td>{this.item(item.data.entityid, query)}</td>
-                            <td className="info">
-                                {isEmpty(item.data.notes) ? <span></span> :
-                                    <NotesTooltip identifier={item.data.entityid} notes={item.data.notes}/>}
-                            </td>
-                            <td className="link"><a href={`/metadata/${item.type}/${item["_id"]}`} target="_blank"
-                                                    onClick={e => e.stopPropagation()}>
-                                <i className="fa fa-external-link"></i>
-                            </a></td>
-                        </tr>
-                    )
+                .map((item, index) => {
+                        switch (item.type) {
+                            case "organisation":
+                                return this.renderOrganisation(item, index, selected, itemSelected);
+                            default:
+                                return this.renderMetadata(item, index, selected, itemSelected, isPolicy, query);
+                        }
+                    }
                 )}
             </tbody>
         </table>;
     }
+
+    renderOrganisation(item, index, selected, itemSelected) {
+        return (
+            <tr key={index}
+                className={selected === index ? "active" : ""}
+                onClick={() => itemSelected(item)}
+                ref={ref => {
+                    if (selected === index) {
+                        this.selectedRow = ref;
+                    }
+                }}>
+                <td className="name">{item.data.name || ""}{item.data.kvkNumber ? ` (${item.data.kvkNumber})` : ""}</td>
+                <td className="info">
+                    {isEmpty(item.data.notes) ? <span></span> :
+                        <NotesTooltip identifier={item["_id"]} notes={item.data.notes}/>}
+                </td>
+                <td className="link"><a href={`/metadata/${item.type}/${item["_id"]}`} target="_blank"
+                                        onClick={e => e.stopPropagation()}>
+                    <i className="fa fa-external-link"></i>
+                </a></td>
+            </tr>
+        );
+    };
+
+    renderMetadata(item, index, selected, itemSelected, isPolicy, query) {
+        return (
+            <tr key={index}
+                className={selected === index ? "active" : ""}
+                onClick={() => itemSelected(item)}
+                ref={ref => {
+                    if (selected === index) {
+                        this.selectedRow = ref;
+                    }
+                }}>
+                <td className="count">{index + 1}</td>
+                <td>
+                    {!isPolicy && this.item(getNameForLanguage(item.data.metaDataFields), query)}
+                    {isPolicy && this.item(item.data.name, query)}
+                </td>
+                <td>
+                    {!isPolicy && this.item(getOrganisationForLanguage(item.data.metaDataFields), query)}
+                    {isPolicy && I18n.t(`topBannerDetails.${item.data.type}`)}
+                </td>
+                <td>{item.type}</td>
+                <td className="state">
+                    <CheckBox name="state" value={item.data.state === "prodaccepted" || isPolicy}
+                              onChange={() => this} readOnly={true}/>
+                </td>
+                <td>{this.item(item.data.entityid, query)}</td>
+                <td className="info">
+                    {isEmpty(item.data.notes) ? <span></span> :
+                        <NotesTooltip identifier={item.data.entityid} notes={item.data.notes}/>}
+                </td>
+                <td className="link"><a href={`/metadata/${item.type}/${item["_id"]}`} target="_blank"
+                                        onClick={e => e.stopPropagation()}>
+                    <i className="fa fa-external-link"></i>
+                </a></td>
+            </tr>
+        );
+    };
 }
 
 Autocomplete.propTypes = {

--- a/manage-gui/src/components/Select.jsx
+++ b/manage-gui/src/components/Select.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import {default as ReactSelect} from "react-select";
+import { default as ReactSelect, components } from "react-select";
 
 import reactSelectStyles from "./reactSelectStyles.js";
 
@@ -18,14 +18,36 @@ export default class Select extends React.PureComponent {
 
         const valueAsOption = typeof value === "string" ? this.valueToOption(value) : value;
 
+        const CustomInput = (props) => {
+            const { menuIsOpen } = props.selectProps;
+
+            return (
+                <components.Input
+                    {...props}
+                    style={{
+                        opacity: menuIsOpen ? 1 : 0,
+                        height: menuIsOpen ? 'auto' : 0,
+                        padding: 0,
+                        margin: 0,
+                        border: 'none',
+                        boxShadow: 'none',
+                        outline: 'none',
+                        backgroundColor: 'transparent'
+                    }}
+                />
+            );
+        };
+
         return (
             <ReactSelect
                 {...rest}
                 className={className}
                 isDisabled={rest.disabled}
-                styles={reactSelectStyles}
+                styles={this.props.styles || reactSelectStyles}
                 inputId={`react-select-${name}`}
                 value={valueAsOption}
+                onMenuClose={() => { document.activeElement?.blur(); }}
+                components={{ Input: CustomInput }}
             />
         );
     }
@@ -38,5 +60,6 @@ Select.propTypes = {
     options: PropTypes.array.isRequired,
     name: PropTypes.string,
     onChange: PropTypes.func.isRequired,
+    styles: PropTypes.object,
     value: PropTypes.oneOfType([PropTypes.object, PropTypes.string, PropTypes.array])
 };

--- a/manage-gui/src/components/metadata/Organisation.jsx
+++ b/manage-gui/src/components/metadata/Organisation.jsx
@@ -1,0 +1,162 @@
+import React from "react";
+
+import "./Organisation.scss";
+import PropTypes from "prop-types";
+import I18n from "i18n-js";
+import String from "../form/String";
+import {isEmpty} from "../../utils/Utils";
+import {validateUniqueField} from "../../api";
+
+export default class Organisation extends React.PureComponent {
+
+    componentDidMount() {
+        window.scrollTo(0, 0);
+        this.validateName(this.props.organisation.data.name || "");
+    }
+
+    onChange = name => value => {
+        if (name === this.props.nameField) {
+            this.validate(name, value);
+        }
+
+        if (value.target) {
+            this.props.onChange(name, value.target.value);
+        } else {
+            this.props.onChange(name, value);
+        }
+    };
+
+    validate = (name, value) => {
+        let valid = true;
+        if (name === this.props.nameField) {
+            valid = valid && !isEmpty(value);
+        }
+        // this.hasError("name", !valid);
+        this.hasError(name, !valid);
+    };
+
+    hasError = (key, value = true) => {
+        if (this.props.errors) {
+            this.props.onError(key, value || undefined);
+        }
+    };
+
+    async validateName(value) {
+        let valid = false;
+
+        if (!isEmpty(value)) {
+            if (value === this.props.originalName) {
+                valid = true;
+            } else {
+                try {
+                    await validateUniqueField("organisation", "name", value)
+                    valid = true;
+                } catch (error) {
+                    valid = false;
+                }
+            }
+        }
+
+        this.hasError(this.props.nameField, !valid);
+    };
+
+    render() {
+        const {
+            organisation: {id, revision, data, notes},
+            guest,
+            nameField,
+            errors
+        } = this.props;
+        const hasErrorName = !isEmpty(data.name) && errors ? errors[nameField] : false;
+        return (
+            <div className="organisation">
+                <table className="data">
+                    <tbody>
+                    <tr>
+                        <td className="key">{I18n.t("metadata.name")}</td>
+                        <td className="value">
+                            <div className="format-input">
+                                <String
+                                    name="name"
+                                    disabled={guest}
+                                    value={data.name || ""}
+                                    onChange={this.onChange("data.name")}
+                                    onBlur={e => this.validateName(e.target.value)}
+                                />
+                                {hasErrorName && (
+                                    <span>
+                                        <i className="fa fa-warning"/>
+                                            {I18n.t("organisation.name.notUnique")}
+                                    </span>
+                                )}
+                                {isEmpty(data.name) && (
+                                    <p className="error">
+                                        {I18n.t("metadata.required", {name: nameField })}
+                                    </p>
+                                )}
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td className="key">KVK Number</td>
+                        <td className="value">
+                            <div className="format-input">
+                                <String
+                                    name="kvkNumber"
+                                    disabled={guest}
+                                    value={data.kvkNumber || ""}
+                                    onChange={this.onChange("data.kvkNumber")}
+                                />
+                            </div>
+                        </td>
+                    </tr>
+                    {id && revision && (
+                        <tr>
+                            <td className="key">{I18n.t("metadata.revision")}</td>
+                            <td className="value">
+                  <span>
+                    {I18n.t("metadata.revisionInfo", {
+                        number: revision.number,
+                        updatedBy: revision.updatedBy,
+                        created: new Date(revision.created).toUTCString()
+                    })}
+                  </span>
+                            </td>
+                        </tr>
+                    )}
+                    <tr>
+                        <td className="key">{I18n.t("metadata.revisionnote")}</td>
+                        <td className="value">
+                            <span>{data.revisionnote}</span>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td className="key">{I18n.t("metadata.notes")}</td>
+                        <td className="value">
+                <textarea
+                    rows={3}
+                    value={data.notes || ""}
+                    onChange={this.onChange("data.notes")}
+                    disabled={guest}
+                />
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        );
+    }
+}
+
+Organisation.defaultProps = {
+    nameField: 'data.name'
+};
+
+Organisation.propTypes = {
+    organisation: PropTypes.object.isRequired,
+    originalName: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onError: PropTypes.func.isRequired,
+    errors: PropTypes.object.isRequired,
+    guest: PropTypes.bool
+};

--- a/manage-gui/src/components/metadata/Organisation.scss
+++ b/manage-gui/src/components/metadata/Organisation.scss
@@ -1,0 +1,71 @@
+@import "../../stylesheets/vars.scss";
+
+.organisation {
+    background-color: white;
+    padding: 20px;
+
+    table.data {
+        width: 100%;
+        border: 1px solid $lighter-grey;
+        border-radius: $br;
+        border-collapse: separate;
+        padding-bottom: 15px;
+        padding-top: 10px;
+
+        tr {
+            &.first {
+                padding: 0;
+                background-color: $lightest-grey;
+            }
+        }
+
+        td {
+            vertical-align: middle;
+
+            &.logo {
+                text-align: center;
+
+                img {
+                    width: 64px;
+                }
+            }
+
+            &.logo-name {
+                vertical-align: middle;
+            }
+
+            &.key {
+                vertical-align: top;
+                padding: 15px;
+                width: 15%;
+            }
+
+            &.value {
+                width: 85%;
+                padding-right: 15px;
+            }
+
+            p.error {
+                color: $red;
+                margin: 10px 0 15px 0;
+            }
+        }
+
+        div.inline-editable {
+            margin-top: 5px;
+        }
+
+        input[type=text], input[type=email], textarea {
+            display: block;
+            width: 100%;
+            border: 1px solid $lighter-grey;
+            padding: 6px;
+            border-radius: $br;
+            font-size: 14px;
+
+            &[disabled] {
+                background-color: $light-grey;
+            }
+        }
+    }
+}

--- a/manage-gui/src/components/metadata/OrganisationEntity.jsx
+++ b/manage-gui/src/components/metadata/OrganisationEntity.jsx
@@ -1,0 +1,210 @@
+import React from "react";
+import "./OrganisationEntity.scss";
+import {getAllEntities, update} from "../../api";
+import PropTypes from "prop-types";
+import I18n from "i18n-js";
+import {Link} from "react-router-dom";
+import {isEmpty, stop} from "../../utils/Utils";
+import NotesTooltip from "../NotesTooltip";
+import {Select} from "../index";
+import {setFlash} from "../../utils/Flash";
+import {getNameForLanguage} from "../../utils/Language";
+
+export default class OrganisationEntity extends React.PureComponent {
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            rawEntities: [],
+            allEntities: [],
+            availableEntities: [],
+            currentEntities: [],
+            entityToRemove: null,
+            showConfirm: false,
+        };
+    }
+
+    componentDidMount() {
+        Promise.all([getAllEntities()]).then(result => {
+            let rawEntities = result[0];
+            this.setState({
+                    rawEntities: rawEntities,
+                    allEntities: rawEntities.map(entity => this.enrichEntity(entity))
+            },
+            () => {
+                this.updateEntities();
+            });
+        });
+    };
+
+    updateEntities = () => {
+        this.setState({
+            availableEntities: this.state.allEntities.filter(e => null == e.organisationid || "" === e.organisationid),
+            currentEntities: this.state.allEntities.filter(e => e.organisationid === this.props.organisation.id)
+        })
+    }
+
+    enrichEntity = (entity) => {
+        return {
+            status: I18n.t(`metadata.${entity.data.state}`),
+            entityid: entity.data.entityid,
+            organisationid: entity.data.organisationid,
+            name:
+                entity.data.metaDataFields["name:en"] ||
+                entity.data.metaDataFields["name:nl"] ||
+                "",
+            id: entity.id,
+            notes: entity.data.notes,
+            type: entity.type
+        };
+    };
+
+    addEntity = (entity) => {
+        this.updateEntity(entity.value, true);
+    }
+
+    removeEntity = (entity) => {
+        const message = I18n.t("organisation_entity.confirmRemoval", { entity: entity.name || entity.id });
+
+        if (window.confirm(message)) {
+            this.updateEntity(entity.id, false);
+        }
+    }
+
+    updateEntity = (entityId, link) => {
+        var metadata = this.state.rawEntities.find(e => e.id === entityId)
+
+        if (link) {
+            metadata.data.organisationid = this.props.organisation.id;
+        } else {
+            delete metadata.data.organisationid;
+        }
+
+        update(metadata).then(json => {
+            if (json.exception || json.error) {
+                setFlash(json.validations || json.message, "error");
+                window.scrollTo(0, 0);
+            } else {
+                const name = json.data.name || getNameForLanguage(json.data.metaDataFields) || "this service";
+                setFlash(
+                    I18n.t("metadata.flash.updated", {
+                        name: name,
+                        revision: json.revision.number
+                    })
+                );
+                const path = encodeURIComponent(`/metadata/organisation/${this.props.organisation.id}/organisation_entity`);
+                this.props.navigate(`/refresh-route/${path}`, {replace: true});
+            }
+        });
+    }
+
+    renderTable = (entries) => {
+        const th = name => (
+            <th
+                key={name}
+                className={name}
+            >
+                {I18n.t(`organisation_entity.headers.${name}`)}
+            </th>
+        );
+        const names = ["name", "type", "entityid", "status", "notes"];
+        return (
+            <section className="connected-entities">
+                <table>
+                    <thead>
+                    <tr>
+                        <th />
+                        {names.map(th)}
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {entries.map(entity => this.renderEntity(entity))}
+                    </tbody>
+                </table>
+            </section>
+        );
+    };
+
+    renderEntity = (entity) => {
+        return (
+            <tr key={entity.entityid}>
+                <td>
+                    <a
+                        onClick={e => {
+                            stop(e);
+                            this.removeEntity(entity);
+                        }}
+                    >
+                        <i className="fa fa-trash-o"/>
+                    </a>
+                </td>
+                <td>
+                    <Link to={`/metadata/${entity.type}/${entity.id}`} target="_blank">
+                        {entity.name}
+                    </Link>
+                </td>
+                <td>{typeLabels[entity.type] || ""}</td>
+                <td>{entity.entityid}</td>
+                <td>{entity.status}</td>
+                <td className="info">
+                    {isEmpty(entity.notes) ? (
+                        <span>
+            </span>
+                    ) : (
+                        <NotesTooltip identifier={entity.entityid} notes={entity.notes}/>
+                    )}
+                </td>
+            </tr>
+        );
+    };
+
+    render() {
+        const {guest, organisation} = this.props;
+        const {availableEntities, currentEntities} = this.state;
+
+        const availableEntityOptions = (availableEntities || []).map(o => ({
+            label: o.name + " ("  + typeLabels[o.type] + ")",
+            value: o.id
+        }))
+
+        return (
+            <div className="organisation-entity">
+                <div className="description">
+                    <h2>{I18n.t("organisation_entity.title")}</h2>
+                    {!guest && (
+                        <p>
+                            {I18n.t("organisation_entity.description", {
+                                organisation: organisation.data.name
+                            })}
+                        </p>
+                    )}
+                </div>
+                <Select
+                    options={availableEntityOptions}
+                    onChange={this.addEntity}
+                    placeholder={I18n.t("organisation_entity.searchPlaceholder")}
+                />
+                {currentEntities.length > 0 &&
+                    this.renderTable(currentEntities)}
+                {currentEntities.length === 0 &&
+                    <span>
+                        {I18n.t("organisation_entity.no_entities")}
+                    </span>
+                }
+
+            </div>
+        );
+    }
+}
+
+const typeLabels = {
+    saml20_sp: "Service Provider",
+    oidc10_rp: "Relying Party"
+};
+
+OrganisationEntity.propTypes = {
+    organisation: PropTypes.object.isRequired,
+    navigate: PropTypes.func.isRequired,
+    guest: PropTypes.bool
+}

--- a/manage-gui/src/components/metadata/OrganisationEntity.scss
+++ b/manage-gui/src/components/metadata/OrganisationEntity.scss
@@ -1,0 +1,76 @@
+@import "../../stylesheets/vars.scss";
+
+.organisation-entity {
+  background-color: white;
+  padding: 20px;
+  white-space: pre-line;
+
+  .description {
+    margin: 15px 0;
+
+    h2 {
+      font-size: 18px;
+      margin-bottom: 10px;
+    }
+  }
+
+  section.connected-entities {
+    margin-top: 15px;
+
+    table {
+      width: 100%;
+
+      th {
+        text-align: left;
+
+        i {
+          margin-left: 15px;
+          color: $lighter-grey;
+
+          &.current, &.reverse {
+            color: $blue;
+          }
+        }
+
+        &.serviceName {
+          width: 15%;
+        }
+
+        &.status {
+          width: 10%;
+        }
+
+        &.name {
+          width: 15%;
+        }
+
+        &.entityid {
+          width: 40%;
+        }
+
+        &.info {
+          width: 20%;
+          text-align: center;
+        }
+      }
+
+      td {
+          .remove {
+              padding: 5px;
+              text-align: center;
+          }
+
+          i.fa-trash-o {
+              color: $red;
+              font-size: 20px;
+          }
+      }
+
+      tbody tr {
+        &:nth-child(odd) {
+          background-color: $lightest-grey;
+        }
+      }
+    }
+  }
+}

--- a/manage-gui/src/locale/en.js
+++ b/manage-gui/src/locale/en.js
@@ -37,6 +37,7 @@ I18n.translations.en = {
         saml20_sp: "Service Providers",
         saml20_idp: "Identity Providers",
         oidc10_rp: "Relying Parties",
+        organisation: "Organisations",
         oauth20_rs: "Resource Servers",
         provisioning: "Provisionings",
         policy: "Policies",
@@ -44,6 +45,7 @@ I18n.translations.en = {
         saml20_sp_single: "Service Provider",
         saml20_idp_single: "Identity Provider",
         oidc10_rp_single: "Relying Party",
+        organisation_single: "Organisation",
         oauth20_rs_single: "Resource Server",
         provisioning_single: "Provisioning",
         policy_single: "Policy",
@@ -75,12 +77,16 @@ I18n.translations.en = {
             connected_applications: "Applications ({{nbr}})",
             auto_refresh: "Auto refresh",
             policy_form: "Configuration",
-            policies: "Policies ({{nbr}})"
+            policies: "Policies ({{nbr}})",
+            organisation: "Organisation",
+            organisation_entity: "Connected entities",
+            sp_organisation: "Organisation",
         },
         notFound: "No Metadata found. You might want to search for this deleted entity in the 'FIND MY METADATA' section in the 'System' tab.",
         existingChangeRequests: "There are orphaned change requests for this deleted entity. You probably want to remove them.",
         deleteChangeRequests: "Delete change requests",
         deleteChangeRequestsFlash: "Orphaned change requests are deleted",
+        selectOrganisation: "Select an organisation to link this entity to",
         entityId: "Entity ID",
         entityIdAlreadyExists: "Entity ID {{entityid}} is already taken.",
         metaDataUrl: "Metadata URL",
@@ -114,6 +120,7 @@ I18n.translations.en = {
         changeRequestsPre: "There are outstanding change request(s). Go to ",
         changeRequestsLink: "requests",
         changeRequestsPost: " to review them.",
+        name: "Name",
         noProvisioning: "No provisionings",
         provisioningTypes: {
             scim: "SCIM",
@@ -217,6 +224,26 @@ I18n.translations.en = {
         restore: "Restore",
         restoreConfirmation: "Are you sure you want to restore deleted {{name}} revision {{number}}?"
 
+    },
+    organisation: {
+        name: {
+            notUnique: "An organisation with this name already exists."
+        }
+    },
+    organisation_entity: {
+        title: "Connected entities",
+        description: "The table below shows all connected Service Providers or OIDC Relying Parties for the organisation '{{organisation}}'.",
+        no_entities: "No connected entities available",
+        searchPlaceholder: "Search, select and add entities to this Organisation",
+        confirmRemoval: "Are you sure you want to unlink {{entity}}?",
+        headers: {
+            status: "Status",
+            type: "Type",
+            entityid: "Entity ID",
+            name: "Name",
+            notes: "Notes"
+        },
+        removedEntitiesDescription: "Removed entities"
     },
     whitelisting: {
         confirmationAllowAll: "Are you sure you want to allow all {{type}} access to '{{name}}'? You will have to add {{type}} one-by-one to selectively deny them again.",

--- a/manage-gui/src/pages/Detail.scss
+++ b/manage-gui/src/pages/Detail.scss
@@ -281,5 +281,18 @@
 
     }
 
+    .metadata-connection {
+        table {
+            tbody {
+                tr {
+                    i.fa {
+                        margin-left: 15px;
+                        color: $blue;
+                    }
+                }
+            }
+        }
+    }
+
 }
 

--- a/manage-server/src/main/java/manage/control/MetaDataController.java
+++ b/manage-server/src/main/java/manage/control/MetaDataController.java
@@ -11,7 +11,6 @@ import manage.service.ImporterService;
 import manage.service.MetaDataService;
 import manage.shibboleth.FederatedUser;
 import manage.web.ScopeEnforcer;
-import org.everit.json.schema.ValidationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ByteArrayResource;
@@ -427,6 +426,12 @@ public class MetaDataController {
         return metaDataRepository.provisioning(identifiers);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping({"/client/metadata/allentities"})
+    public List<MetaData> getAllEntities() {
+        return metaDataRepository.retrieveAllEntities();
+    }
+
     @PreAuthorize("hasAnyRole('ADMIN', 'READ')")
     @GetMapping({"/client/allowedEntities/{type}/{id}", "/internal/allowedEntities/{type}/{id}"})
     public List<Map> allowedEntities(@PathVariable("type") String type, @PathVariable("id") String id) {
@@ -462,6 +467,16 @@ public class MetaDataController {
     public List<MetaData> rawSearchPost(@PathVariable("type") String type, @RequestBody String query)
         throws UnsupportedEncodingException {
         return metaDataService.retrieveRawSearch(type, query);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/client/metadata/validate-unique-field/{type}/{name}/{value}")
+    public ResponseEntity<Boolean> validateUniqueField(@PathVariable String type,
+                                                       @PathVariable String name,
+                                                       @PathVariable String value) {
+
+        this.metaDataRepository.validateFieldUnique(type, name, value);
+        return ResponseEntity.status(HttpStatus.OK).body(true);
     }
 
     @PreAuthorize("hasAnyRole('ADMIN', 'READ')")

--- a/manage-server/src/main/java/manage/exception/ValueNotUniqueException.java
+++ b/manage-server/src/main/java/manage/exception/ValueNotUniqueException.java
@@ -1,0 +1,13 @@
+package manage.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+public class ValueNotUniqueException extends RuntimeException {
+
+    public ValueNotUniqueException(String message) {
+        super(message);
+    }
+
+}

--- a/manage-server/src/main/java/manage/hook/EntityIdDuplicationHook.java
+++ b/manage-server/src/main/java/manage/hook/EntityIdDuplicationHook.java
@@ -51,6 +51,7 @@ public class EntityIdDuplicationHook extends MetaDataHookAdapter {
             case EntityType.PDP:
             case EntityType.PROV:
             case EntityType.STT:
+            case EntityType.ORG:
                 entityTypes.add(entityType);
                 break;
             case EntityType.RS:

--- a/manage-server/src/main/java/manage/hook/EntityIdReconcilerHook.java
+++ b/manage-server/src/main/java/manage/hook/EntityIdReconcilerHook.java
@@ -24,7 +24,9 @@ public class EntityIdReconcilerHook extends MetaDataHookAdapter {
 
     @Override
     public boolean appliesForMetaData(MetaData metaData) {
-        return !metaData.getType().equals(EntityType.STT.getType()) && !metaData.getType().equals(EntityType.PROV.getType());
+        return !metaData.getType().equals(EntityType.STT.getType()) &&
+            !metaData.getType().equals(EntityType.PROV.getType()) &&
+            !metaData.getType().equals(EntityType.ORG.getType());
     }
 
     @Override

--- a/manage-server/src/main/java/manage/hook/MetaDataHookConfiguration.java
+++ b/manage-server/src/main/java/manage/hook/MetaDataHookConfiguration.java
@@ -46,7 +46,8 @@ public class MetaDataHookConfiguration {
                 new RequiredAttributesHook(metaDataAutoConfiguration),
                 new ProvisioningHook(metaDataRepository, metaDataAutoConfiguration),
                 new EncryptionHook(keyStore, cryptoEnabled),
-                new ProvisioningApplicationDeletionHook(metaDataRepository)));
+                new ProvisioningApplicationDeletionHook(metaDataRepository),
+                new OrganisationDeletionHook(metaDataRepository, metaDataAutoConfiguration)));
     }
 
 

--- a/manage-server/src/main/java/manage/hook/OrganisationDeletionHook.java
+++ b/manage-server/src/main/java/manage/hook/OrganisationDeletionHook.java
@@ -1,0 +1,48 @@
+package manage.hook;
+
+import manage.api.AbstractUser;
+import manage.conf.MetaDataAutoConfiguration;
+import manage.model.EntityType;
+import manage.model.MetaData;
+import manage.repository.MetaDataRepository;
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.ValidationException;
+
+public class OrganisationDeletionHook extends MetaDataHookAdapter {
+
+    private final MetaDataAutoConfiguration metaDataAutoConfiguration;
+
+    private final MetaDataRepository metaDataRepository;
+
+    private final String ORGANISATION_ID_FIELD = "organisationid";
+
+    public OrganisationDeletionHook(MetaDataRepository metaDataRepository,
+                                    MetaDataAutoConfiguration metaDataAutoConfiguration) {
+
+        this.metaDataRepository = metaDataRepository;
+        this.metaDataAutoConfiguration = metaDataAutoConfiguration;
+    }
+
+    @Override
+    public boolean appliesForMetaData(MetaData metaData) {
+        return metaData.getType().equals(EntityType.ORG.getType());
+    }
+
+    @Override
+    public MetaData preDelete(MetaData metaDataToBeDeleted, AbstractUser user) {
+        String id = metaDataToBeDeleted.getId();
+
+        if (metaDataRepository.retrieveAllEntities().stream().anyMatch(
+            entity -> null != entity.getData() && null != entity.getData().get(ORGANISATION_ID_FIELD) &&
+                entity.getData().get(ORGANISATION_ID_FIELD).equals(id))) {
+
+            Schema schema = metaDataAutoConfiguration.schema(EntityType.ORG.getType());
+            throw new ValidationException(
+                schema,
+                "Organisation cannot be deleted; it still has linked entities.");
+        }
+
+        return metaDataToBeDeleted;
+    }
+
+}

--- a/manage-server/src/main/java/manage/model/EntityType.java
+++ b/manage-server/src/main/java/manage/model/EntityType.java
@@ -12,7 +12,8 @@ public enum EntityType {
     STT("single_tenant_template", SP.getJanusDbValue()),
     SRAM("sram", SP.getJanusDbValue()),
     PROV("provisioning"),
-    PDP("policy");
+    PDP("policy"),
+    ORG("organisation");
 
     private final String type;
     private final String janusDbValue;

--- a/manage-server/src/main/resources/metadata_configuration/oidc10_rp.schema.json
+++ b/manage-server/src/main/resources/metadata_configuration/oidc10_rp.schema.json
@@ -50,6 +50,9 @@
       "type": "string",
       "format": "basic-authentication-user"
     },
+    "organisationid": {
+      "type": "string"
+    },
     "type": {
       "type": "string",
       "enum": [

--- a/manage-server/src/main/resources/metadata_configuration/organisation.schema.json
+++ b/manage-server/src/main/resources/metadata_configuration/organisation.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "organisation",
+  "order": 6,
+  "type": "object",
+  "properties": {
+    "eid": {
+      "type": "number"
+    },
+    "entityid": {
+      "type": "string",
+      "format": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "kvkNumber": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "notes": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "metaDataFields": {
+      "type": "object",
+      "properties": {},
+      "patternProperties": {},
+      "required": [],
+      "additionalProperties": false
+    },
+    "revisionnote": {
+      "type": "string",
+      "format": "string"
+    },
+    "patternProperties": {
+      "name": {
+        "type": "string",
+        "info": "The friendly name of the Organisation."
+      },
+      "kvkNumber": {
+        "type": "string",
+        "info": "The friendly name of the Organisation."
+      },
+      "notes": {
+        "type": "string",
+        "info": "Additional information regarding the Organisation"
+      }
+    }
+  },
+  "required": [
+    "name"
+  ],
+  "additionalProperties": false
+}

--- a/manage-server/src/main/resources/metadata_configuration/saml20_sp.schema.json
+++ b/manage-server/src/main/resources/metadata_configuration/saml20_sp.schema.json
@@ -79,6 +79,9 @@
     "entityid": {
       "type": "string"
     },
+    "organisationid": {
+      "type": "string"
+    },
     "type": {
       "type": "string",
       "enum": [

--- a/manage-server/src/main/resources/metadata_templates/organisation.template.json
+++ b/manage-server/src/main/resources/metadata_templates/organisation.template.json
@@ -1,0 +1,7 @@
+{
+  "metaDataFields": {},
+  "revisionnote": "",
+  "name": "",
+  "kvkNumber": "",
+  "notes": ""
+}

--- a/manage-server/src/test/java/manage/AbstractIntegrationTest.java
+++ b/manage-server/src/test/java/manage/AbstractIntegrationTest.java
@@ -56,7 +56,7 @@ public abstract class AbstractIntegrationTest implements TestUtils {
     @LocalServerPort
     protected int port;
 
-    private static List<MetaData> metaDataList;
+    protected static List<MetaData> metaDataList;
 
     @BeforeEach
     public void before() throws Exception {

--- a/manage-server/src/test/java/manage/hook/EntityIdDuplicationHookTest.java
+++ b/manage-server/src/test/java/manage/hook/EntityIdDuplicationHookTest.java
@@ -55,17 +55,19 @@ class EntityIdDuplicationHookTest extends AbstractIntegrationTest {
     void prePutInValid() {
         Arrays.stream(EntityType.values())
             .forEach(entityType -> {
-                List<MetaData> allByType = metaDataRepository.findAllByType(entityType.getType());
-                MetaData metaData = allByType.getFirst();
-                //This is allowed
-                this.entityIdDuplicationHook.prePut(null, metaData, apiUser);
-                //Set new unique id
-                ReflectionTestUtils.setField(metaData, "id", UUID.randomUUID().toString());
-                assertThrows(ValidationException.class, () ->
-                    this.entityIdDuplicationHook.prePut(null, metaData, apiUser));
-                ReflectionTestUtils.setField(metaData, "id", null);
-                assertThrows(ValidationException.class, () ->
-                    this.entityIdDuplicationHook.prePost(metaData, apiUser));
+                if (!EntityType.ORG.equals(entityType)) {
+                    List<MetaData> allByType = metaDataRepository.findAllByType(entityType.getType());
+                    MetaData metaData = allByType.get(0);
+                    //This is allowed
+                    this.entityIdDuplicationHook.prePut(null, metaData, apiUser);
+                    //Set new unique id
+                    ReflectionTestUtils.setField(metaData, "id", UUID.randomUUID().toString());
+                    assertThrows(ValidationException.class, () ->
+                        this.entityIdDuplicationHook.prePut(null, metaData, apiUser));
+                    ReflectionTestUtils.setField(metaData, "id", null);
+                    assertThrows(ValidationException.class, () ->
+                        this.entityIdDuplicationHook.prePost(metaData, apiUser));
+                }
             });
 
     }

--- a/manage-server/src/test/resources/json/meta_data_seed.json
+++ b/manage-server/src/test/resources/json/meta_data_seed.json
@@ -830,5 +830,24 @@
         "OrganizationName:en": "SURF"
       }
     }
+  },
+  { "id": 18,
+    "_id": "750357b2-8cf1-462d-94fe-48342305fc3e",
+    "_class": "manage.model.MetaData",
+    "data": {
+      "metaDataFields": {},
+      "revisionnote": "Restore of revision: 4",
+      "name": "Stichting Kennisnet",
+      "kvkNumber": "27244834",
+      "notes": "Remarks regarding the Organisation",
+      "eid": 8
+    },
+    "revision": {
+      "number": 6,
+      "created": "2018-06-15T08:20:34.575Z",
+      "updatedBy": "Thomas Beekman"
+    },
+    "type": "organisation",
+    "version": 6
   }
 ]

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <release>21</release>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -84,7 +84,7 @@
                                     <version>3.8.4</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>21</version>
+                                    <version>${java.version}</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
This PR contains the introduction of the Organisation entity. The Organisation entity is an object which can be used to bundle a number of Service Providers and Relying Parties as a means to group common services provided by a single organisation. 

The Organisation entity is implemented as a MetaData record. Links to an Organisation is handled in the Service Provider and Relying Party metadata by the field "organisationid". 

From the GUI it is possible to link a Service Provider or a Relying Party to an existing Organisation by selecting the available Organisation from the Connection tab. If an Organisation entity is open, the Connected Entities tab can be used to quickly link existing Service Providers and Relying Parties ("entities") to the Organisation. An Organisation cannot be deleted as long as there are active links; after removal of the links the Organisation can be deleted.

Currently, the only additional data element which an Organisation has is the KVK Number field. This can be extended in the future. 

The implementation is not intrusive, and therefore, a feature flag has not been implemented. 