### PR TITLE
Add configuration for disabling unused schemas

### DIFF
--- a/manage-server/src/main/resources/application-devconf.yml
+++ b/manage-server/src/main/resources/application-devconf.yml
@@ -1,6 +1,7 @@
 ---
 metadata_configuration_path: file:///config/metadata_configuration/
 metadata_templates_path: file:///config/metadata_templates/
+disabled_metadata_schemas:
 
 base_domain: dev.openconext.local
 environment: prod

--- a/manage-server/src/main/resources/application.yml
+++ b/manage-server/src/main/resources/application.yml
@@ -60,6 +60,7 @@ loa_levels: "http://localhost/assurance/loa1.5,http://localhost/assurance/loa2,h
 metadata_configuration_path: classpath:/metadata_configuration
 metadata_templates_path: classpath:/metadata_templates
 metadata_export_path: classpath:/metadata_export
+disabled_metadata_schemas:
 
 security:
   backdoor_user_name: backdoor

--- a/manage-server/src/test/java/manage/conf/MetaDataAutoConfigurationTest.java
+++ b/manage-server/src/test/java/manage/conf/MetaDataAutoConfigurationTest.java
@@ -20,7 +20,8 @@ public class MetaDataAutoConfigurationTest implements TestUtils {
     private final MetaDataAutoConfiguration subject = new MetaDataAutoConfiguration(
             objectMapper,
             new ClassPathResource("metadata_configuration"),
-            new ClassPathResource("metadata_templates"));
+            new ClassPathResource("metadata_templates"),
+            "provisioning.schema.json,sram.schema.json");
 
     public MetaDataAutoConfigurationTest() throws IOException {
     }
@@ -109,5 +110,11 @@ public class MetaDataAutoConfigurationTest implements TestUtils {
     @Test
     public void schemaNotExists() {
         assertThrows(IllegalArgumentException.class, () -> subject.schema("bogus"));
+    }
+
+    @Test
+    public void schemaNotAllowedFiltered() {
+        assertThrows(IllegalArgumentException.class, () -> subject.schema("provisioning"));
+        assertThrows(IllegalArgumentException.class, () -> subject.schema("sram"));
     }
 }

--- a/manage-server/src/test/java/manage/hook/EmptyRevisionHookTest.java
+++ b/manage-server/src/test/java/manage/hook/EmptyRevisionHookTest.java
@@ -21,7 +21,8 @@ public class EmptyRevisionHookTest implements TestUtils {
     private EmptyRevisionHook subject = new EmptyRevisionHook(new MetaDataAutoConfiguration(
             objectMapper,
             new ClassPathResource("metadata_configuration"),
-            new ClassPathResource("metadata_templates")));
+            new ClassPathResource("metadata_templates"),
+        ""));
 
     public EmptyRevisionHookTest() throws IOException {
     }

--- a/manage-server/src/test/java/manage/hook/IdentityProviderBrinCodeHookTest.java
+++ b/manage-server/src/test/java/manage/hook/IdentityProviderBrinCodeHookTest.java
@@ -20,7 +20,8 @@ public class IdentityProviderBrinCodeHookTest implements TestUtils {
     private final IdentityProviderBrinCodeHook identityProviderBrinCodeHook = new IdentityProviderBrinCodeHook(new MetaDataAutoConfiguration(
         objectMapper,
         new ClassPathResource("metadata_configuration"),
-        new ClassPathResource("metadata_templates")));
+        new ClassPathResource("metadata_templates"),
+        ""));
 
     public IdentityProviderBrinCodeHookTest() throws IOException {
     }

--- a/manage-server/src/test/java/manage/hook/OidcValidationHookTest.java
+++ b/manage-server/src/test/java/manage/hook/OidcValidationHookTest.java
@@ -21,7 +21,8 @@ public class OidcValidationHookTest implements TestUtils {
     private final OidcValidationHook subject = new OidcValidationHook(new MetaDataAutoConfiguration(
         objectMapper,
         new ClassPathResource("metadata_configuration"),
-        new ClassPathResource("metadata_templates")), false);
+        new ClassPathResource("metadata_templates"),
+        ""), false);
 
     public OidcValidationHookTest() throws IOException {
     }
@@ -104,7 +105,8 @@ public class OidcValidationHookTest implements TestUtils {
         OidcValidationHook hook = new OidcValidationHook(new MetaDataAutoConfiguration(
             objectMapper,
             new ClassPathResource("metadata_configuration"),
-            new ClassPathResource("metadata_templates")),
+            new ClassPathResource("metadata_templates"),
+            ""),
             true);
 
 

--- a/manage-server/src/test/java/manage/hook/RequiredAttributesHookTest.java
+++ b/manage-server/src/test/java/manage/hook/RequiredAttributesHookTest.java
@@ -25,7 +25,8 @@ class RequiredAttributesHookTest implements TestUtils {
     private final RequiredAttributesHook subject = new RequiredAttributesHook(new MetaDataAutoConfiguration(
             objectMapper,
             new ClassPathResource("metadata_configuration"),
-            new ClassPathResource("metadata_templates")));
+            new ClassPathResource("metadata_templates"),
+            ""));
 
     public RequiredAttributesHookTest() throws IOException {
     }

--- a/manage-server/src/test/java/manage/hook/TypeSafetyHookTest.java
+++ b/manage-server/src/test/java/manage/hook/TypeSafetyHookTest.java
@@ -17,7 +17,8 @@ public class TypeSafetyHookTest implements TestUtils {
     private MetaDataAutoConfiguration metaDataAutoConfiguration = new MetaDataAutoConfiguration(
             objectMapper,
             new ClassPathResource("metadata_configuration"),
-            new ClassPathResource("metadata_templates"));
+            new ClassPathResource("metadata_templates"),
+            "");
     private TypeSafetyHook subject = new TypeSafetyHook(metaDataAutoConfiguration);
 
     public TypeSafetyHookTest() throws IOException {

--- a/manage-server/src/test/java/manage/service/ImporterServiceTest.java
+++ b/manage-server/src/test/java/manage/service/ImporterServiceTest.java
@@ -30,7 +30,8 @@ public class ImporterServiceTest implements TestUtils {
             subject = new ImporterService(new MetaDataAutoConfiguration(
                     objectMapper,
                     new ClassPathResource("metadata_configuration"),
-                    new ClassPathResource("metadata_templates")),
+                    new ClassPathResource("metadata_templates"),
+                    ""),
                     new MockEnvironment(),
                     "nl,pt,en",
                     null);
@@ -148,7 +149,7 @@ public class ImporterServiceTest implements TestUtils {
 
     @Test
     public void multiplicity() throws IOException, XMLStreamException {
-        MetaDataAutoConfiguration metaDataAutoConfiguration = new MetaDataAutoConfiguration(objectMapper, new ClassPathResource("metadata_configuration"), new ClassPathResource("metadata_templates"));
+        MetaDataAutoConfiguration metaDataAutoConfiguration = new MetaDataAutoConfiguration(objectMapper, new ClassPathResource("metadata_configuration"), new ClassPathResource("metadata_templates"), "");
         Map<String, Object> spSchema = metaDataAutoConfiguration.schemaRepresentation(EntityType.SP);
         Map.class.cast(Map.class.cast(Map.class.cast(Map.class.cast(spSchema.get("properties")).get("metaDataFields")).get("patternProperties")).get("^AssertionConsumerService:([0-3]{0,1}[0-9]{1}):index$")).put("multiplicity", 15);
         ImporterService alteredSubject = new ImporterService(metaDataAutoConfiguration, new MockEnvironment(), "nl,en,pt", null);

--- a/manage-server/src/test/resources/test.properties
+++ b/manage-server/src/test/resources/test.properties
@@ -13,6 +13,7 @@ management.info.git.mode=full
 metadata_configuration_path=classpath:/metadata_configuration
 metadata_export_path=classpath:/metadata_export
 metadata_templates_path=classpath:/metadata_templates
+disabled_metadata_schemas=
 oidc.user=manage
 oidc.password=secret
 oidc.url=https://oidc.test2.surfconext.nl/oidc/api/clients


### PR DESCRIPTION
Hi all,

We have the usage scenario where not all of the schema tabs should be served to our end users. Therefore, we have added the possibility to disable a selection of schemas in order to only serve the tabs that are used. We wanted to share this version with the community as their might be more users with this specific need.

Kind regards!