### PR TITLE
Remove non-current endpoints when importing new SAML metadata

### DIFF
--- a/manage-gui/src/components/metadata/Import.jsx
+++ b/manage-gui/src/components/metadata/Import.jsx
@@ -190,6 +190,25 @@ export default class Import extends React.Component {
                         };
                     }
                 });
+                // Also remove fields that are no longer valid. SP and IDP can have multiple fields
+                // if a url is removed from the metadata it should not be ignored.
+                const currentMedataFields = Object.keys(currentMetaData[key]);
+                currentMedataFields.forEach(field => {
+                    if (
+                        !metaDataFields.includes(field) && (
+                            field.includes("AssertionConsumerService") ||
+                            field.includes("SingleLogoutService") ||
+                            field.includes("SingleSignOnService")
+                        )
+                    ) {
+                        value[field] = {
+                            value: null,
+                            selected: true,
+                            current: currentMetaData[key][field]
+                        };
+                    }
+                })
+
                 if (Object.keys(value).length === 0) {
                     delete results[key];
                 }


### PR DESCRIPTION
When importing metadata from **Enter a valid SAML metadata endpoint** information is updated, but if existing information is removed from the metadata it will not be removed from manage.

There are a few fields in the metadata where this can not be ignored and should be updated:

- **AssertionConsumerService** 
for ServiceProviders
- **SingleLogoutService** 
for ServiceProviders
- **SingleSignOnService** 
for IdentityProviders

With the suggested improvements when MetaDataFields are missing from one of the above mentioned fields they will now be removed in Manage and the changes are shown visibly for the user.

Example of use case:
When a ServiceProviders moves domain and creates new metadata with one less AssertionConsumerService binding these do not get removed when importing the new metadata. And will make it possible for users to be send to a wrong domain. 

