### PR TITLE
Fixes #459 - CSV contain all fields

### DIFF
--- a/manage-gui/src/__tests__/utils/ObjectToKeyValues.test.js
+++ b/manage-gui/src/__tests__/utils/ObjectToKeyValues.test.js
@@ -1,4 +1,4 @@
-import {objectToKeyValues} from "../../utils/ObjectToKeyValues";
+import {flattenObjectEntries} from "../../utils/FlattenObjectEntries";
 
 test("objectToKeyValue() - contains all keys", () => {
     const testObject = {
@@ -14,7 +14,7 @@ test("objectToKeyValue() - contains all keys", () => {
     }
     const input = Object.entries(testObject)
 
-    const result = objectToKeyValues(input);
+    const result = flattenObjectEntries(input);
 
     expect(result.map(([key]) => key)).toEqual([ 'a', 'b', 'c.c1', 'c.c2', 'c.c3.c3a'])
 })

--- a/manage-gui/src/__tests__/utils/ObjectToKeyValues.test.js
+++ b/manage-gui/src/__tests__/utils/ObjectToKeyValues.test.js
@@ -1,0 +1,20 @@
+import {objectToKeyValues} from "../../utils/ObjectToKeyValues";
+
+test("objectToKeyValue() - contains all keys", () => {
+    const testObject = {
+        a: 'aValue',
+        b: 'bValue',
+        c: {
+            c1: 'c1Value',
+            c2: 'c2Value',
+            c3: {
+                c3a: 'c3aValue'
+            }
+        }
+    }
+    const input = Object.entries(testObject)
+
+    const result = objectToKeyValues(input);
+
+    expect(result.map(([key]) => key)).toEqual([ 'a', 'b', 'c.c1', 'c.c2', 'c.c3.c3a'])
+})

--- a/manage-gui/src/pages/API.jsx
+++ b/manage-gui/src/pages/API.jsx
@@ -10,6 +10,7 @@ import debounce from "lodash.debounce";
 import {CheckBox, NotesTooltip, Select} from '../components'
 import {SelectMetaDataType, SelectNewEntityAttribute, SelectNewMetaDataField} from "../components/metadata"
 import {getNameForLanguage} from "../utils/Language";
+import {objectToKeyValues} from "../utils/ObjectToKeyValues";
 
 const papaparseConfig = {
     quotes: true,
@@ -338,28 +339,8 @@ export default class API extends React.PureComponent {
 
 
     renderSearchResultsTablePrintable = (searchResults) => {
-        // Todo move to utils and add unit tests
-        const objectToKeyValue = (inputEntries, keyPrefix) =>
-            inputEntries.reduce((acc, curr) => {
-                const [currKey, currValue] = curr;
-
-                if (Array.isArray(currValue)) {
-                    console.error(`Arrays are currently not supported, skips processing the value of "${currKey}"`);
-                    acc.push([currKey, currValue]);
-                    return acc;
-                }
-
-                if (typeof currValue === "object") {
-                    const nestedInputEntries = Object.entries(currValue);
-                    acc.push(...objectToKeyValue(nestedInputEntries, currKey));
-                    return acc;
-                }
-                const theKey = keyPrefix ? `${keyPrefix}.${currKey}` : currKey
-                acc.push([theKey, currValue]);
-                return acc;
-            }, [])
-
-        const flattenedSearchResults = searchResults.map((row) => Object.fromEntries(objectToKeyValue(Object.entries(row))));
+        const flattenedSearchResults = searchResults.map((row) =>
+            Object.fromEntries(objectToKeyValues(Object.entries(row))));
         const csvResult = Papaparse.unparse({
             fields: Object.keys(flattenedSearchResults[0]),
             data: flattenedSearchResults.map((row) => Object.values(row))

--- a/manage-gui/src/pages/API.jsx
+++ b/manage-gui/src/pages/API.jsx
@@ -10,7 +10,7 @@ import debounce from "lodash.debounce";
 import {CheckBox, NotesTooltip, Select} from '../components'
 import {SelectMetaDataType, SelectNewEntityAttribute, SelectNewMetaDataField} from "../components/metadata"
 import {getNameForLanguage} from "../utils/Language";
-import {objectToKeyValues} from "../utils/ObjectToKeyValues";
+import {flattenArrayOfObjects} from "../utils/FlattenObjectEntries";
 
 const papaparseConfig = {
     quotes: true,
@@ -339,8 +339,7 @@ export default class API extends React.PureComponent {
 
 
     renderSearchResultsTablePrintable = (searchResults) => {
-        const flattenedSearchResults = searchResults.map((row) =>
-            Object.fromEntries(objectToKeyValues(Object.entries(row))));
+        const flattenedSearchResults = flattenArrayOfObjects(searchResults);
         const csvResult = Papaparse.unparse({
             fields: Object.keys(flattenedSearchResults[0]),
             data: flattenedSearchResults.map((row) => Object.values(row))

--- a/manage-gui/src/utils/FlattenObjectEntries.js
+++ b/manage-gui/src/utils/FlattenObjectEntries.js
@@ -1,4 +1,4 @@
-export const objectToKeyValues = (inputEntries, keyPrefix) =>
+export const flattenObjectEntries = (inputEntries, keyPrefix) =>
     inputEntries.reduce((acc, curr) => {
         const [currKey, currValue] = curr;
         const currKeyWithPrefix = keyPrefix ? `${keyPrefix}.${currKey}` : currKey
@@ -11,10 +11,16 @@ export const objectToKeyValues = (inputEntries, keyPrefix) =>
 
         if (typeof currValue === "object") {
             const nestedInputEntries = Object.entries(currValue);
-            acc.push(...objectToKeyValues(nestedInputEntries, currKeyWithPrefix));
+            acc.push(...flattenObjectEntries(nestedInputEntries, currKeyWithPrefix));
             return acc;
         }
 
         acc.push([currKeyWithPrefix, currValue]);
         return acc;
     }, []);
+
+export const flattenObject = (inputObject) =>
+    Object.fromEntries(flattenObjectEntries(Object.entries(inputObject)))
+
+export const flattenArrayOfObjects = (arrayOfObjects) =>
+    arrayOfObjects.map((arrayItem) => flattenObject(arrayItem))

--- a/manage-gui/src/utils/ObjectToKeyValues.js
+++ b/manage-gui/src/utils/ObjectToKeyValues.js
@@ -1,0 +1,20 @@
+export const objectToKeyValues = (inputEntries, keyPrefix) =>
+    inputEntries.reduce((acc, curr) => {
+        const [currKey, currValue] = curr;
+        const currKeyWithPrefix = keyPrefix ? `${keyPrefix}.${currKey}` : currKey
+
+        if (Array.isArray(currValue)) {
+            console.error(`Arrays are currently not supported, skips processing the value of "${currKey}"`);
+            acc.push([currKey, currValue]);
+            return acc;
+        }
+
+        if (typeof currValue === "object") {
+            const nestedInputEntries = Object.entries(currValue);
+            acc.push(...objectToKeyValues(nestedInputEntries, currKeyWithPrefix));
+            return acc;
+        }
+
+        acc.push([currKeyWithPrefix, currValue]);
+        return acc;
+    }, []);


### PR DESCRIPTION
#459 

- Flattens object before making a CSV

```
{
        a: 'aValue',
        b: 'bValue',
        c: {
            c1: 'c1Value',
            c2: 'c2Value',
            c3: {
                c3a: 'c3aValue'
            }
        }
}
```

Output (first row only)
```
'a', 'b', 'c.c1', 'c.c2', 'c.c3.c3a'
```