### PR TITLE
Provide an enriched info actuator endpoint for monitoring purposes

### DIFF
--- a/manage-server/pom.xml
+++ b/manage-server/pom.xml
@@ -287,6 +287,19 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                        <configuration>
+                            <additionalProperties>
+                                <java_version>${java.version}</java_version>
+                                <spring_boot_version>${project.parent.parent.version}</spring_boot_version>
+                            </additionalProperties>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>io.github.git-commit-id</groupId>

--- a/manage-server/src/main/java/manage/actuator/ReleaseDaysInfoContributor.java
+++ b/manage-server/src/main/java/manage/actuator/ReleaseDaysInfoContributor.java
@@ -1,0 +1,36 @@
+package manage.actuator;
+
+import org.springframework.boot.actuate.info.Info;
+import org.springframework.boot.actuate.info.InfoContributor;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+
+@Component
+public class ReleaseDaysInfoContributor implements InfoContributor {
+
+    private static final String RELEASE_DAYS_KEY = "days_since_release";
+
+    private final BuildProperties buildProperties;
+
+    public ReleaseDaysInfoContributor(BuildProperties buildProperties) {
+        this.buildProperties = buildProperties;
+    }
+
+    @Override
+    public void contribute(Info.Builder builder) {
+        long currentDays = 0L;
+
+        if (null != buildProperties.getTime()) {
+            LocalDate releaseDate = LocalDate.ofInstant(buildProperties.getTime(), ZoneId.systemDefault());
+            LocalDate currentDate = LocalDate.ofInstant(Instant.now(), ZoneId.systemDefault());
+            currentDays = ChronoUnit.DAYS.between(releaseDate, currentDate);
+        }
+        builder.withDetail(RELEASE_DAYS_KEY, currentDays);
+    }
+
+}

--- a/manage-server/src/main/java/manage/conf/BuildPropertiesConfig.java
+++ b/manage-server/src/main/java/manage/conf/BuildPropertiesConfig.java
@@ -1,0 +1,57 @@
+package manage.conf;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Properties;
+
+@Configuration
+public class BuildPropertiesConfig {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BuildPropertiesConfig.class);
+
+    @Bean
+    public BuildProperties buildProperties(@Qualifier("webApplicationContext") ResourceLoader resourceLoader) {
+        try {
+            Resource resource = resourceLoader.getResource("classpath:META-INF/build-info.properties");
+            if (!resource.exists()) {
+                LOGGER.warn("META-INF/build-info.properties not found, using default build properties");
+                Properties defaultProperties = new Properties();
+                defaultProperties.put("time", Instant.now().toString());
+                defaultProperties.put("version", "0.0.0-TEST");
+                defaultProperties.put("name", "test-build");
+                defaultProperties.put("group", "test-group");
+                defaultProperties.put("artifact", "test-artifact");
+                return new BuildProperties(defaultProperties);
+            }
+
+            Properties properties = PropertiesLoaderUtils.loadProperties(resource);
+            Properties flattenedProperties = new Properties();
+            properties.forEach((key, value) -> {
+                String newKey = key.toString().replaceFirst("^build\\.", "");
+                flattenedProperties.put(newKey, value);
+            });
+
+            return new BuildProperties(flattenedProperties);
+        } catch (IOException e) {
+            LOGGER.error("Error loading build-info.properties", e);
+            Properties defaultProperties = new Properties();
+            defaultProperties.put("time", Instant.now().toString());
+            defaultProperties.put("version", "0.0.0-ERROR");
+            defaultProperties.put("name", "error-build");
+            defaultProperties.put("group", "error-group");
+            defaultProperties.put("artifact", "error-artifact");
+            return new BuildProperties(defaultProperties);
+        }
+    }
+
+}

--- a/manage-server/src/test/java/manage/conf/BuildPropertiesConfigTest.java
+++ b/manage-server/src/test/java/manage/conf/BuildPropertiesConfigTest.java
@@ -1,0 +1,90 @@
+package manage.conf;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class BuildPropertiesConfigTest {
+
+    @Mock
+    private ResourceLoader resourceLoader;
+
+    @InjectMocks
+    private final BuildPropertiesConfig buildPropertiesConfig = new BuildPropertiesConfig();
+
+
+    @Test
+    void buildPropertiesMissing() {
+        Resource mockResource = mock(Resource.class);
+        when(mockResource.exists()).thenReturn(false);
+        when(resourceLoader.getResource(any())).thenReturn(mockResource);
+
+        BuildProperties buildProperties = buildPropertiesConfig.buildProperties(resourceLoader);
+
+        assertEquals("0.0.0-TEST", buildProperties.getVersion());
+        assertEquals("test-build", buildProperties.getName());
+        assertEquals("test-group", buildProperties.getGroup());
+        assertEquals("test-artifact", buildProperties.getArtifact());
+    }
+
+    @Test
+    void buildPropertiesAvailable() throws IOException {
+        Resource mockResource = mock(Resource.class);
+
+        when(mockResource.exists()).thenReturn(true);
+        when(mockResource.getInputStream()).thenReturn(
+                new ByteArrayInputStream((
+                        """
+                                build.artifact=manage-server
+                                build.group=org.openconext
+                                build.java_version=21
+                                build.name=manage-server
+                                build.spring_boot_version=3.5.7
+                                build.time=2026-05-13T14\\:50\\:24.823Z
+                                build.version=9.7.3-SNAPSHOT""").getBytes()));
+
+        when(resourceLoader.getResource(any())).thenReturn(mockResource);
+
+        BuildProperties buildProperties = buildPropertiesConfig.buildProperties(resourceLoader);
+
+        assertEquals("manage-server", buildProperties.getArtifact());
+        assertEquals("org.openconext", buildProperties.getGroup());
+        assertEquals("manage-server", buildProperties.getName());
+        assertEquals("9.7.3-SNAPSHOT", buildProperties.getVersion());
+        assertEquals(Instant.parse("2026-05-13T14:50:24.823Z"), buildProperties.getTime());
+        assertEquals("21", buildProperties.get("java_version"));
+        assertEquals("3.5.7", buildProperties.get("spring_boot_version"));
+    }
+
+    @Test
+    void buildPropertiesMissingIOException() throws IOException {
+        Resource mockResource = mock(Resource.class);
+
+        when(mockResource.exists()).thenReturn(true);
+        doThrow(IOException.class).when(mockResource).getInputStream();
+
+        when(resourceLoader.getResource(any())).thenReturn(mockResource);
+
+        BuildProperties buildProperties = buildPropertiesConfig.buildProperties(resourceLoader);
+
+        assertEquals("0.0.0-ERROR", buildProperties.getVersion());
+        assertEquals("error-build", buildProperties.getName());
+        assertEquals("error-group", buildProperties.getGroup());
+        assertEquals("error-artifact", buildProperties.getArtifact());
+    }
+
+}


### PR DESCRIPTION
This PR proposes enrichment of the info actuator endpoint (/manage/api/internal/info). With this PR, the endpoint will also show information regarding the used Java and Spring Boot versions, and will show the amount of days passed since the release was build. This information can be used by application monitoring to determine whether a new release of the application and its middleware is required.